### PR TITLE
Add static cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,18 @@
+# Cosmic Helix Renderer
+
+Static HTML+Canvas renderer encoding layered sacred geometry for offline use.
+
+## Files
+- `index.html` — entry point; open directly in a browser.
+- `js/helix-renderer.mjs` — ES module of pure drawing routines.
+- `data/palette.json` — optional palette file; safe defaults load if missing.
+
+## Usage
+1. Keep the directory structure as-is.
+2. Double-click `index.html` (no server or network needed).
+3. If the palette file is absent, a notice shows and default colors are used.
+
+## Design Notes
+- ND-safe: static imagery, high readability, soft contrast.
+- Layer order: Vesica field → Tree-of-Life → Fibonacci curve → double-helix lattice.
+- Geometry constants follow 3, 7, 9, 11, 22, 33, 99, and 144 numerology.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,151 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine waves with connectors)
+
+  All geometry avoids motion/animation; palette chosen for soft contrast.
+*/
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesicaField(ctx, width, height, palette.layers[0], NUM);
+  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.ink, NUM);
+  drawFibonacciCurve(ctx, width, height, palette.layers[2], NUM);
+  drawHelixLattice(ctx, width, height, palette.layers[3], NUM);
+}
+
+/* Vesica field: calm grid of overlapping circles using 3x7 pattern */
+function drawVesicaField(ctx, w, h, color, NUM) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  const cols = NUM.THREE;
+  const rows = NUM.SEVEN;
+  const r = Math.min(w / (cols * 2), h / (rows * 2));
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const cx = r + col * r * 2 + (row % 2 === 0 ? 0 : r);
+      const cy = r + row * r;
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(cx + r, cy, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+  ctx.restore();
+}
+
+/* Tree-of-Life: nodes (ink) and 22 connecting paths */
+function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, NUM) {
+  ctx.save();
+  const xs = [w / 4, w / 2, (w * 3) / 4]; // left, center, right columns
+  const ys = [
+    h / NUM.ELEVEN,
+    h / NUM.NINE,
+    (h * 3) / NUM.ELEVEN,
+    (h * 5) / NUM.ELEVEN,
+    (h * 7) / NUM.ELEVEN,
+    (h * 9) / NUM.ELEVEN
+  ];
+  // Ten nodes arranged top to bottom
+  const nodes = [
+    [xs[1], ys[0]], // 0 Keter
+    [xs[0], ys[1]], // 1 Chokmah
+    [xs[2], ys[1]], // 2 Binah
+    [xs[0], ys[2]], // 3 Chesed
+    [xs[2], ys[2]], // 4 Geburah
+    [xs[1], ys[3]], // 5 Tiferet
+    [xs[0], ys[4]], // 6 Netzach
+    [xs[2], ys[4]], // 7 Hod
+    [xs[1], ys[5]], // 8 Yesod
+    [xs[1], h - ys[0]] // 9 Malkuth
+  ];
+  const edges = [
+    [0,1],[0,2],[1,2],[1,3],[1,5],[2,4],[2,5],
+    [3,4],[3,5],[4,5],[3,6],[3,8],[4,7],[4,8],
+    [5,6],[5,7],[5,8],[6,7],[6,8],[7,8],[6,9],[7,9]
+  ]; // 22 paths
+  ctx.strokeStyle = pathColor;
+  edges.forEach(([a,b])=>{
+    ctx.beginPath();
+    ctx.moveTo(nodes[a][0], nodes[a][1]);
+    ctx.lineTo(nodes[b][0], nodes[b][1]);
+    ctx.stroke();
+  });
+  ctx.fillStyle = nodeColor;
+  const r = 6;
+  nodes.forEach(([x,y])=>{
+    ctx.beginPath();
+    ctx.arc(x,y,r,0,Math.PI*2);
+    ctx.fill();
+  });
+  ctx.restore();
+}
+
+/* Fibonacci curve: static polyline using 11 segments */
+function drawFibonacciCurve(ctx, w, h, color, NUM) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.beginPath();
+  let a = 1, b = 1;
+  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
+  let x = w / 2;
+  let y = h / 2;
+  ctx.moveTo(x, y);
+  let angle = 0;
+  for (let i = 0; i < NUM.ELEVEN; i++) {
+    const len = b * scale;
+    x += len * Math.cos(angle);
+    y += len * Math.sin(angle);
+    ctx.lineTo(x, y);
+    [a, b] = [b, a + b];
+    angle += Math.PI / 2;
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+/* Double-helix lattice: two sinusoids with 99 vertical connectors */
+function drawHelixLattice(ctx, w, h, color, NUM) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  const amp = h / 4;
+  const cycles = NUM.THREE;
+  // first strand
+  ctx.beginPath();
+  for (let x = 0; x <= w; x++) {
+    const y = h / 2 + amp * Math.sin((cycles * 2 * Math.PI * x) / w);
+    if (x === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  // second strand phase-shifted by PI
+  ctx.beginPath();
+  for (let x = 0; x <= w; x++) {
+    const y = h / 2 + amp * Math.sin((cycles * 2 * Math.PI * x) / w + Math.PI);
+    if (x === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  // vertical connectors
+  for (let i = 0; i <= NUM.NINETYNINE; i++) {
+    const x = (w / NUM.NINETYNINE) * i;
+    const y1 = h / 2 + amp * Math.sin((cycles * 2 * Math.PI * x) / w);
+    const y2 = h / 2 + amp * Math.sin((cycles * 2 * Math.PI * x) / w + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+  ctx.restore();
+}


### PR DESCRIPTION
## Summary
- add offline index.html entry with ND-safe defaults
- implement helix-renderer.mjs with vesica grid, tree-of-life, fibonacci curve, and helix lattice
- include palette.json and usage notes in README_RENDERER.md

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd8f5186883288974f5528670bd0c