### PR TITLE
feat: add offline cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,21 @@
+# Cosmic Helix Renderer
+
+Static, offline canvas demo for layered sacred geometry. No build step, no network calls, ND-safe by design.
+
+## Layers
+1. **Vesica field** — intersecting circles seed the grid (constant 3 + 7 + 9)
+2. **Tree-of-Life scaffold** — 10 nodes and 22 connective paths
+3. **Fibonacci curve** — logarithmic spiral using 144 sampled points
+4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs
+
+## Use
+- Open `index.html` directly in any modern browser.
+- Optional: edit `data/palette.json` to change colors (file is read locally; if removed, a calm fallback palette is used).
+
+## ND-safe choices
+- No animation, autoplay, or flashing.
+- Gentle contrast with readable inks on dark background.
+- Layered geometry respects depth without relying on motion.
+
+## Numerology constants
+Constants are exposed in `index.html` as `NUM` and feed the renderer. Values: 3, 7, 9, 11, 22, 33, 99, 144.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,151 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted strands with rungs)
+
+  No motion, no external dependencies. ASCII only.
+*/
+
+export function renderHelix(ctx, { width, height, palette, NUM }) {
+  ctx.save();
+  // Clear and set background
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[2], palette.layers[1], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette, NUM);
+  ctx.restore();
+}
+
+// Layer 1 ---------------------------------------------------------------
+function drawVesica(ctx, w, h, color, NUM) {
+  /* Vesica field: calm outline grid built from overlapping circles.
+     ND-safe: thin lines, low density. */
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  const r = Math.min(w, h) / NUM.THREE; // base radius from sacred triad
+  const step = r / NUM.SEVEN;           // spacing guided by 7
+  for (let y = r; y < h; y += step * NUM.NINE) {
+    for (let x = r; x < w; x += step * NUM.NINE) {
+      ctx.beginPath();
+      ctx.arc(x - step, y, r, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(x + step, y, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+  ctx.restore();
+}
+
+// Layer 2 ---------------------------------------------------------------
+function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
+  /* Tree-of-Life: simplified sephirot layout, 10 nodes + 22 paths.
+     ND-safe: solid nodes, gentle lines. */
+  ctx.save();
+  const nodes = [
+    [0.5, 0.05], // Kether
+    [0.2, 0.2],  // Chokmah
+    [0.8, 0.2],  // Binah
+    [0.2, 0.4],  // Chesed
+    [0.8, 0.4],  // Geburah
+    [0.5, 0.5],  // Tiphereth
+    [0.2, 0.7],  // Netzach
+    [0.8, 0.7],  // Hod
+    [0.5, 0.85], // Yesod
+    [0.5, 0.95]  // Malkuth
+  ];
+  const paths = [
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],[3,6],[4,7],[5,6],[5,7],
+    [6,8],[7,8],[8,9],[1,4],[2,3],[1,5],[2,6],[3,8],[4,8],[5,9],[6,9]
+  ]; // 22 connections guided by NUM.TWENTYTWO
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 1;
+  paths.slice(0, NUM.TWENTYTWO).forEach(([a,b]) => {
+    ctx.beginPath();
+    ctx.moveTo(nodes[a][0]*w, nodes[a][1]*h);
+    ctx.lineTo(nodes[b][0]*w, nodes[b][1]*h);
+    ctx.stroke();
+  });
+  ctx.fillStyle = nodeColor;
+  nodes.forEach(([x,y]) => {
+    ctx.beginPath();
+    ctx.arc(x*w, y*h, 6, 0, Math.PI*2);
+    ctx.fill();
+  });
+  ctx.restore();
+}
+
+// Layer 3 ---------------------------------------------------------------
+function drawFibonacci(ctx, w, h, color, NUM) {
+  /* Fibonacci logarithmic spiral approximated by polyline.
+     ND-safe: static, soft stroke. */
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  const center = { x: w/NUM.THREE, y: h/NUM.THREE };
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const turns = NUM.THREE; // three rotations
+  const segs = NUM.ONEFORTYFOUR; // smoothness
+  ctx.beginPath();
+  for (let i = 0; i <= segs; i++) {
+    const t = (turns * 2 * Math.PI) * (i / segs);
+    const r = Math.pow(phi, t / (2 * Math.PI));
+    const scale = Math.min(w,h) / NUM.SEVEN;
+    const x = center.x + scale * r * Math.cos(t);
+    const y = center.y + scale * r * Math.sin(t);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+// Layer 4 ---------------------------------------------------------------
+function drawHelix(ctx, w, h, palette, NUM) {
+  /* Double-helix lattice: two sine-wave strands with cross rungs.
+     ND-safe: static strands, no flashing, readable contrast. */
+  ctx.save();
+  const amp = h / NUM.NINE;
+  const waves = NUM.ELEVEN;             // helix turns
+  const steps = NUM.NINETYNINE;         // sampling points
+  // strand A
+  ctx.strokeStyle = palette.layers[4];
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const x = (w / steps) * i;
+    const y = h/2 + amp * Math.sin((i/steps) * waves * 2 * Math.PI);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  // strand B phase-shifted
+  ctx.strokeStyle = palette.layers[5];
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const x = (w / steps) * i;
+    const y = h/2 + amp * Math.sin((i/steps) * waves * 2 * Math.PI + Math.PI);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+  // rungs
+  ctx.strokeStyle = palette.ink;
+  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
+    const x = (w / NUM.THIRTYTHREE) * i;
+    const phase = (x / w) * waves * 2 * Math.PI;
+    const y1 = h/2 + amp * Math.sin(phase);
+    const y2 = h/2 + amp * Math.sin(phase + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+  ctx.restore();
+}


### PR DESCRIPTION
## Summary
- add standalone canvas renderer with vesica, tree-of-life, fibonacci spiral, and static double helix
- bundle local palette with fallback and document numerology constants

## Testing
- `node --check js/helix-renderer.mjs`
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('data/palette.json','utf8'));console.log('palette ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68bbd987ed208328bea9b87b891f11ff