### PR TITLE
Add duplicate line cleaner

### DIFF
--- a/README_DEDUPER.md
+++ b/README_DEDUPER.md
@@ -1,0 +1,10 @@
+# Duplicate Line Cleaner
+
+This repo may collect accidental duplicate lines. Run `node tools/dedupe.mjs` to clean text files.
+
+```sh
+node tools/dedupe.mjs       # removes consecutive duplicate lines
+node tools/dedupe.mjs --check  # report only
+```
+
+Safe to run offline; skips `.git` and binary files.

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,6 +1,5 @@
 # Cosmic Helix Renderer
 
-
 Static, offline canvas demo for layered sacred geometry. No build step, no network calls, ND-safe by design.
 
 ## Layers
@@ -20,15 +19,3 @@ Static, offline canvas demo for layered sacred geometry. No build step, no netwo
 
 ## Numerology constants
 Constants are exposed in `index.html` as `NUM` and feed the renderer. Values: 3, 7, 9, 11, 22, 33, 99, 144.
-=======
-Static, offline HTML+Canvas demo that layers Vesica, Tree-of-Life, Fibonacci spiral, and a double-helix lattice.
-
-## Use
-- Open `index.html` directly in any modern browser (no server required).
-- Optional palette values are in `data/palette.json`; if missing, a safe fallback palette is used.
-
-## Design Notes
-- ND-safe: calm contrast, no motion, no flashing.
-- Geometry is parameterized with numerology constants (3,7,9,11,22,33,99,144).
-- Pure ES module with no dependencies or build step.
-

--- a/tools/dedupe.mjs
+++ b/tools/dedupe.mjs
@@ -1,0 +1,46 @@
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// dedupeLines: remove consecutive duplicate lines
+export function dedupeLines(lines) {
+  const out = [];
+  let prev = null;
+  for (const line of lines) {
+    if (line !== prev) out.push(line);
+    prev = line;
+  }
+  return out;
+}
+
+function processFile(file, write) {
+  const text = readFileSync(file, 'utf8');
+  const lines = text.split('\n');
+  const clean = dedupeLines(lines);
+  if (clean.length !== lines.length) {
+    if (write) writeFileSync(file, clean.join('\n'), 'utf8');
+    console.log((write ? 'deduped' : 'duplicates in') + ' ' + file);
+    return 1;
+  }
+  return 0;
+}
+
+function walk(dir, write) {
+  let count = 0;
+  for (const entry of readdirSync(dir)) {
+    if (entry === '.git') continue;
+    const full = join(dir, entry);
+    const info = statSync(full);
+    if (info.isDirectory()) {
+      count += walk(full, write);
+    } else if (/\.(?:js|mjs|html|md|json)$/u.test(entry)) {
+      count += processFile(full, write);
+    }
+  }
+  return count;
+}
+
+if (import.meta.url === 'file://' + process.argv[1]) {
+  const write = !process.argv.includes('--check');
+  const total = walk(process.cwd(), write);
+  if (total === 0) console.log('no duplicate lines found');
+}


### PR DESCRIPTION
## Summary
- add Node-based dedupe script to strip accidental repeated lines
- document duplicate line cleaner usage
- clean duplicate content from renderer README

## Testing
- `node tools/dedupe.mjs --check`


------
https://chatgpt.com/codex/tasks/task_e_68be029d41d083289bc26e0af840ef42