### PR TITLE
Finalize ND-safe cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,17 +1,16 @@
 # Cosmic Helix Renderer
 
-
 Static, offline canvas demo for layered sacred geometry. No build step, no network calls, ND-safe by design.
 
 ## Layers
-1. **Vesica field** — intersecting circles seed the grid (constant 3 + 7 + 9)
-2. **Tree-of-Life scaffold** — 10 nodes and 22 connective paths
+1. **Vesica field** — intersecting circles seed the grid (3,7,9)
+2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths
 3. **Fibonacci curve** — logarithmic spiral using 144 sampled points
 4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs
 
 ## Use
 - Open `index.html` directly in any modern browser.
-- Optional: edit `data/palette.json` to change colors (file is read locally; if removed, a calm fallback palette is used).
+- Optional: edit `data/palette.json` to change colors; if missing, a calm fallback palette is used.
 
 ## ND-safe choices
 - No animation, autoplay, or flashing.
@@ -20,15 +19,3 @@ Static, offline canvas demo for layered sacred geometry. No build step, no netwo
 
 ## Numerology constants
 Constants are exposed in `index.html` as `NUM` and feed the renderer. Values: 3, 7, 9, 11, 22, 33, 99, 144.
-=======
-Static, offline HTML+Canvas demo that layers Vesica, Tree-of-Life, Fibonacci spiral, and a double-helix lattice.
-
-## Use
-- Open `index.html` directly in any modern browser (no server required).
-- Optional palette values are in `data/palette.json`; if missing, a safe fallback palette is used.
-
-## Design Notes
-- ND-safe: calm contrast, no motion, no flashing.
-- Geometry is parameterized with numerology constants (3,7,9,11,22,33,99,144).
-- Pure ES module with no dependencies or build step.
-

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,8 +1,6 @@
 {
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-
   "layers": [
     "#b1c7ff",
     "#89f7fe",

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -4,44 +4,39 @@
 
   Layers:
     1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
-    3) Fibonacci curve (log spiral polyline; static)
-
+    2) Tree-of-Life scaffold (10 nodes + 22 paths)
+    3) Fibonacci curve (log spiral polyline)
     4) Double-helix lattice (two phase-shifted strands with rungs)
 
-  No motion, no external dependencies. ASCII only.
+  No motion, no external deps. ASCII only, small pure functions.
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.save();
-  // Clear and set background
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
   drawVesica(ctx, width, height, palette.layers[0], NUM);
   drawTree(ctx, width, height, palette.layers[2], palette.layers[1], NUM);
   drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette, NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
   ctx.restore();
 }
 
 // Layer 1 ---------------------------------------------------------------
 function drawVesica(ctx, w, h, color, NUM) {
-  /* Vesica field: calm outline grid built from overlapping circles.
-     ND-safe: thin lines, low density. */
+  /* Vesica field: calm outline grid of intersecting circles.
+     ND-safe: thin strokes, generous spacing. */
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 1;
-  const r = Math.min(w, h) / NUM.THREE; // base radius from sacred triad
-  const step = r / NUM.SEVEN;           // spacing guided by 7
+  const r = Math.min(w, h) / NUM.THREE;
+  const step = r / NUM.NINE;
+  const offset = r / NUM.SEVEN;
   for (let y = r; y < h; y += step * NUM.NINE) {
     for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
+      ctx.beginPath(); ctx.arc(x - offset, y, r, 0, Math.PI * 2); ctx.stroke();
+      ctx.beginPath(); ctx.arc(x + offset, y, r, 0, Math.PI * 2); ctx.stroke();
     }
   }
   ctx.restore();
@@ -49,37 +44,29 @@ function drawVesica(ctx, w, h, color, NUM) {
 
 // Layer 2 ---------------------------------------------------------------
 function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  /* Tree-of-Life: simplified sephirot layout, 10 nodes + 22 paths.
+  /* Tree-of-Life: 10 nodes + 22 paths.
      ND-safe: solid nodes, gentle lines. */
   ctx.save();
-  const nodes = [
-    [0.5, 0.05], // Kether
-    [0.2, 0.2],  // Chokmah
-    [0.8, 0.2],  // Binah
-    [0.2, 0.4],  // Chesed
-    [0.8, 0.4],  // Geburah
-    [0.5, 0.5],  // Tiphereth
-    [0.2, 0.7],  // Netzach
-    [0.8, 0.7],  // Hod
-    [0.5, 0.85], // Yesod
-    [0.5, 0.95]  // Malkuth
+  const n = [
+    [0.5,0.05], [0.2,0.2], [0.8,0.2], [0.2,0.4], [0.8,0.4],
+    [0.5,0.5], [0.2,0.7], [0.8,0.7], [0.5,0.85], [0.5,0.95]
   ];
-  const paths = [
+  const e = [
     [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],[3,6],[4,7],[5,6],[5,7],
     [6,8],[7,8],[8,9],[1,4],[2,3],[1,5],[2,6],[3,8],[4,8],[5,9],[6,9]
-  ]; // 22 connections guided by NUM.TWENTYTWO
+  ];
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 1;
-  paths.slice(0, NUM.TWENTYTWO).forEach(([a,b]) => {
+  e.slice(0, NUM.TWENTYTWO).forEach(([a,b]) => {
     ctx.beginPath();
-    ctx.moveTo(nodes[a][0]*w, nodes[a][1]*h);
-    ctx.lineTo(nodes[b][0]*w, nodes[b][1]*h);
+    ctx.moveTo(n[a][0]*w, n[a][1]*h);
+    ctx.lineTo(n[b][0]*w, n[b][1]*h);
     ctx.stroke();
   });
   ctx.fillStyle = nodeColor;
-  nodes.forEach(([x,y]) => {
+  n.forEach(([x,y]) => {
     ctx.beginPath();
-    ctx.arc(x*w, y*h, 6, 0, Math.PI*2);
+    ctx.arc(x*w, y*h, NUM.ELEVEN/NUM.TWENTYTWO*6, 0, Math.PI*2); // gentle radius
     ctx.fill();
   });
   ctx.restore();
@@ -87,22 +74,20 @@ function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
 
 // Layer 3 ---------------------------------------------------------------
 function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci logarithmic spiral approximated by polyline.
-     ND-safe: static, soft stroke. */
+  /* Fibonacci spiral: static polyline using 144 samples.
+     ND-safe: single stroke. */
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
-  const center = { x: w/NUM.THREE, y: h/NUM.THREE };
   const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = NUM.THREE; // three rotations
-  const segs = NUM.ONEFORTYFOUR; // smoothness
+  const center = { x: w/NUM.THREE, y: h/NUM.THREE };
   ctx.beginPath();
-  for (let i = 0; i <= segs; i++) {
-    const t = (turns * 2 * Math.PI) * (i / segs);
-    const r = Math.pow(phi, t / (2 * Math.PI));
-    const scale = Math.min(w,h) / NUM.SEVEN;
-    const x = center.x + scale * r * Math.cos(t);
-    const y = center.y + scale * r * Math.sin(t);
+  for (let i = 0; i <= NUM.ONEFORTYFOUR; i++) {
+    const t = (i / NUM.ONEFORTYFOUR) * NUM.THREE * 2 * Math.PI;
+    const r = Math.pow(phi, t / (2*Math.PI));
+    const s = Math.min(w,h) / NUM.SEVEN;
+    const x = center.x + s * r * Math.cos(t);
+    const y = center.y + s * r * Math.sin(t);
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
@@ -110,163 +95,39 @@ function drawFibonacci(ctx, w, h, color, NUM) {
 }
 
 // Layer 4 ---------------------------------------------------------------
-function drawHelix(ctx, w, h, palette, NUM) {
-  /* Double-helix lattice: two sine-wave strands with cross rungs.
-     ND-safe: static strands, no flashing, readable contrast. */
+function drawHelix(ctx, w, h, strandColor, rungColor, NUM) {
+  /* Double-helix lattice: two phase-shifted sine strands with rungs.
+     ND-safe: static lines, no flashing. */
   ctx.save();
   const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;             // helix turns
-  const steps = NUM.NINETYNINE;         // sampling points
-  // strand A
-  ctx.strokeStyle = palette.layers[4];
+  const turns = NUM.ELEVEN;
+  const steps = NUM.NINETYNINE;
   ctx.lineWidth = 2;
+  ctx.strokeStyle = strandColor;
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const x = (w / steps) * i;
-    const y = h/2 + amp * Math.sin((i/steps) * waves * 2 * Math.PI);
+    const y = h/2 + amp * Math.sin((i/steps) * turns * Math.PI * 2);
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
-  // strand B phase-shifted
-  ctx.strokeStyle = palette.layers[5];
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const x = (w / steps) * i;
-    const y = h/2 + amp * Math.sin((i/steps) * waves * 2 * Math.PI + Math.PI);
+    const y = h/2 + amp * Math.sin((i/steps) * turns * Math.PI * 2 + Math.PI);
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
-  // rungs
-  ctx.strokeStyle = palette.ink;
+  ctx.strokeStyle = rungColor;
+  ctx.lineWidth = 1;
   for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
     const x = (w / NUM.THIRTYTHREE) * i;
-    const phase = (x / w) * waves * 2 * Math.PI;
+    const phase = (x / w) * turns * Math.PI * 2;
     const y1 = h/2 + amp * Math.sin(phase);
     const y2 = h/2 + amp * Math.sin(phase + Math.PI);
-    ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
-    ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(x, y1); ctx.lineTo(x, y2); ctx.stroke();
   }
   ctx.restore();
-
-export function renderHelix(ctx, opts) {
-  const { width, height, palette, NUM } = opts;
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  const [vesicaColor, treeColor, fibColor, helixColor] = palette.layers;
-  drawVesica(ctx, width, height, vesicaColor, NUM);
-  drawTree(ctx, width, height, treeColor, NUM);
-  drawFibonacci(ctx, width, height, fibColor, NUM);
-  drawHelix(ctx, width, height, helixColor, NUM);
 }
 
-/* ND-safe: no motion; each layer is drawn once in calm contrast. */
-function drawVesica(ctx, w, h, color, NUM) {
-  const r = h / NUM.THREE;
-  const offset = r / NUM.THIRTYTHREE;
-  const cx1 = w / 2 - r / 2;
-  const cx2 = w / 2 + r / 2;
-  const cy = h / 2;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = NUM.THREE / NUM.THREE;
-  ctx.beginPath(); ctx.arc(cx1, cy, r - offset, 0, Math.PI * 2); ctx.stroke();
-  ctx.beginPath(); ctx.arc(cx2, cy, r - offset, 0, Math.PI * 2); ctx.stroke();
-}
-
-function drawTree(ctx, w, h, color, NUM) {
-  const r = NUM.ELEVEN; // node radius
-  const nodes = [
-    {x:w/2,       y:h/NUM.NINE},
-    {x:w*0.65,    y:h*0.2},
-    {x:w*0.35,    y:h*0.2},
-    {x:w*0.75,    y:h*0.4},
-    {x:w*0.25,    y:h*0.4},
-    {x:w/2,       y:h*0.5},
-    {x:w*0.75,    y:h*0.6},
-    {x:w*0.25,    y:h*0.6},
-    {x:w/2,       y:h*0.7},
-    {x:w/2,       y:h*0.9}
-  ];
-  const edges = [
-    [0,1],[0,2],[1,2],
-    [1,3],[2,4],[3,4],
-    [3,5],[4,5],
-    [3,6],[4,7],
-    [5,6],[5,7],
-    [6,8],[7,8],
-    [6,9],[7,9],
-    [8,9],
-    [1,4],[2,3],
-    [2,5],[1,5],
-    [5,8]
-  ]; // 22 paths
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  edges.forEach(([a,b])=>{
-    const pa = nodes[a], pb = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(pa.x, pa.y);
-    ctx.lineTo(pb.x, pb.y);
-    ctx.stroke();
-  });
-  ctx.fillStyle = color;
-  nodes.forEach(n=>{
-    ctx.beginPath();
-    ctx.arc(n.x, n.y, r, 0, Math.PI*2);
-    ctx.fill();
-  });
-}
-
-function drawFibonacci(ctx, w, h, color, NUM) {
-  const cx = w / 2;
-  const cy = h / 2;
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const a = Math.min(w, h) / NUM.NINETYNINE;
-  const pts = [];
-  for (let i = 0; i < NUM.TWENTYTWO; i++) {
-    const angle = i / NUM.SEVEN * Math.PI;
-    const radius = a * Math.pow(phi, angle);
-    pts.push([cx + radius * Math.cos(angle), cy + radius * Math.sin(angle)]);
-  }
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  pts.forEach((p, i) => {
-    if (i === 0) ctx.moveTo(p[0], p[1]);
-    else ctx.lineTo(p[0], p[1]);
-  });
-  ctx.stroke();
-}
-
-function drawHelix(ctx, w, h, color, NUM) {
-  const amp = h / NUM.SEVEN;
-  const step = w / NUM.ONEFORTYFOUR;
-  const turns = NUM.NINE;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-
-  ctx.beginPath();
-  for (let x = 0; x <= w; x += step) {
-    const y = h/2 + Math.sin((x/w) * Math.PI * turns) * amp;
-    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  ctx.beginPath();
-  for (let x = 0; x <= w; x += step) {
-    const y = h/2 + Math.sin((x/w) * Math.PI * turns + Math.PI) * amp;
-    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-    }
-  ctx.stroke();
-
-  ctx.lineWidth = 0.5;
-  for (let i = 0; i <= NUM.ELEVEN; i++) {
-    const x = (w / NUM.ELEVEN) * i;
-    ctx.beginPath();
-    ctx.moveTo(x, h/3);
-    ctx.lineTo(x, h*2/3);
-    ctx.stroke();
-  }
-}
+/* ND-safe: all layers are drawn once, no motion or async tasks. */


### PR DESCRIPTION
## Summary
- Rebuild helix renderer into small pure functions drawing vesica grid, Tree-of-Life, Fibonacci spiral, and double helix without motion.
- Clean palette data and document numerology-based color slots.
- Trim README for offline ND-safe usage guidance.

## Testing
- `node --check js/helix-renderer.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68be3089ef5083289de33c1019d89d1a