### PR TITLE
Replace helix renderer and update tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Celebrate Diversity: embrace multiple cultures, genres, and disciplines—every 
 
 This “Magical Mystery House” unites open-world exploration, spiral learning, and reverence for artistic mastery. By continually adding rooms, customizing experiences, and preserving every creative output, it becomes a living Codex that grows with its visitors—turning exploration into enlightenment and art into an ever-expanding celebration.
 
-## Build Tasks
+## Task Status
+- [x] Offline helix renderer with palette fallback.
 - [ ] Craft ASCII cathedral rooms reflecting elemental architecture.
 - [ ] Integrate Tree-of-Life lore into new ring puzzles.
 - [ ] Expand palette with cultural motifs while staying ND-safe.

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,10 +3,10 @@
 Static, offline canvas demo for layered sacred geometry. No build step, no network calls, ND-safe by design.
 
 ## Layers
-
 1. **Vesica field** — intersecting circles seed the grid (3,7,9)
-2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths
+2. **Tree-of-Life scaffold** — 10 nodes with 22 paths
 3. **Fibonacci curve** — logarithmic spiral using 144 sampled points
+4. **Double-helix lattice** — two phase-shifted strands with 33 rungs
 
 - Open `index.html` directly in any modern browser.
 - Optional: edit `data/palette.json` to change colors; if missing, a calm fallback palette is used.
@@ -17,14 +17,4 @@ Static, offline canvas demo for layered sacred geometry. No build step, no netwo
 - Layer order preserves depth without motion.
 
 ## Numerology constants
-
-Constants are exposed in `index.html` as `NUM` and feed the renderer. Values: 3, 7, 9, 11, 22, 33, 99, 144.
-
-
-
 Values exposed as `NUM` in `index.html`: 3, 7, 9, 11, 22, 33, 99, 144.
-
-Constants are exposed in `index.html` as `NUM` and feed the renderer. Values: 3, 7, 9, 11, 22, 33, 99, 144.
-
-
-

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,17 +1,5 @@
 {
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
-
   "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-
-  "layers": [
-    "#b1c7ff",
-    "#89f7fe",
-    "#a0ffa1",
-    "#ffd27f",
-    "#f5a3ff",
-    "#d0d0e6"
-  ]
-
 }
-

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -2,32 +2,23 @@
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-  Layers: Vesica field, Tree-of-Life scaffold, Fibonacci curve, double-helix lattice.
-  All functions are pure and render once; no motion or external deps.
-
-
   Layers:
     1) Vesica field (intersecting circles)
-
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
+    2) Tree-of-Life scaffold (10 nodes, 22 paths)
     3) Fibonacci curve (log spiral polyline)
     4) Double-helix lattice (two phase-shifted strands)
 
-  No motion, no external deps. ASCII only, small pure functions.
-
+  All routines are pure, draw once, and avoid motion or external dependencies.
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.save();
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
+
+  // Layer order preserves readable depth
   drawVesica(ctx, width, height, palette.layers[0], NUM);
-
-  drawTree(ctx, width, height, palette.layers[1], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[2], NUM);
-  drawHelix(ctx, width, height, palette.layers[3], NUM);
-
-  drawTree(ctx, width, height, palette.layers[2], palette.layers[1], NUM);
+  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
   drawFibonacci(ctx, width, height, palette.layers[3], NUM);
   drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
 
@@ -36,266 +27,121 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
 
 // Layer 1 ---------------------------------------------------------------
 function drawVesica(ctx, w, h, color, NUM) {
-
-  /* Vesica field: calm outline grid built from overlapping circles.
-     ND-safe: thin lines, low density. */
-  const r = Math.min(w, h) / NUM.THREE; // base radius from sacred triad
-  const step = r / NUM.SEVEN;           // spacing guided by 7
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
-      ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
-
-
-  /* Vesica field: low-density intersecting circles.
-     ND-safe: thin lines, calm spacing. */
-
-  /* Vesica field: calm outline grid of intersecting circles.
-     ND-safe: thin strokes, generous spacing. */
-
+  // Vesica field: calm intersecting circles
   ctx.save();
+  const r = Math.min(w, h) / NUM.THREE;       // base radius via sacred triad
+  const step = r / NUM.SEVEN;                 // spacing guided by 7
   ctx.strokeStyle = color;
   ctx.lineWidth = 1;
-  const r = Math.min(w, h) / NUM.THREE;
 
-  const step = r / NUM.SEVEN;
   for (let y = r; y < h; y += step * NUM.NINE) {
     for (let x = r; x < w; x += step * NUM.NINE) {
       ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
       ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
-
-  const step = r / NUM.NINE;
-  const offset = r / NUM.SEVEN;
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath(); ctx.arc(x - offset, y, r, 0, Math.PI * 2); ctx.stroke();
-      ctx.beginPath(); ctx.arc(x + offset, y, r, 0, Math.PI * 2); ctx.stroke();
-
-
     }
   }
+  ctx.restore();
 }
 
 // Layer 2 ---------------------------------------------------------------
-
-function drawTree(ctx, w, h, color, NUM) {
-  /* Tree-of-Life: 10 nodes + 22 paths in balanced layout. */
+function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
+  // Tree-of-Life: 10 sephirot nodes and 22 connecting paths
+  ctx.save();
   const nodes = [
-    [0.5, 0.05],[0.2,0.2],[0.8,0.2],
-    [0.2,0.4],[0.8,0.4],[0.5,0.5],
-    [0.2,0.7],[0.8,0.7],[0.5,0.85],[0.5,0.95]
+    [0.5, 0.05], [0.2, 0.2], [0.8, 0.2],
+    [0.2, 0.4], [0.8, 0.4], [0.5, 0.5],
+    [0.2, 0.7], [0.8, 0.7], [0.5, 0.85], [0.5, 0.95]
   ];
   const paths = [
     [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],
     [3,6],[4,7],[5,6],[5,7],
     [6,8],[7,8],[8,9],[1,4],[2,3],[1,5],[2,6],[3,8],[4,8],[5,9],[6,9]
   ];
-  ctx.strokeStyle = color;
 
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-
-  /* Tree-of-Life: 10 nodes, 22 paths.
-     ND-safe: solid nodes, gentle lines. */
-  ctx.save();
-  const nodes = [
-    [0.5, 0.05], [0.2, 0.2], [0.8, 0.2], [0.2, 0.4], [0.8, 0.4],
-    [0.5, 0.5], [0.2, 0.7], [0.8, 0.7], [0.5, 0.85], [0.5, 0.95]
-
-  /* Tree-of-Life: 10 nodes + 22 paths.
-     ND-safe: solid nodes, gentle lines. */
-  ctx.save();
-  const n = [
-    [0.5,0.05], [0.2,0.2], [0.8,0.2], [0.2,0.4], [0.8,0.4],
-    [0.5,0.5], [0.2,0.7], [0.8,0.7], [0.5,0.85], [0.5,0.95]
-
-  ];
-  const e = [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],[3,6],[4,7],[5,6],[5,7],
-    [6,8],[7,8],[8,9],[1,4],[2,3],[1,5],[2,6],[3,8],[4,8],[5,9],[6,9]
-  ];
+  // paths
   ctx.strokeStyle = pathColor;
-
   ctx.lineWidth = 1;
-  e.slice(0, NUM.TWENTYTWO).forEach(([a,b]) => {
+  paths.slice(0, NUM.TWENTYTWO).forEach(([a, b]) => {
     ctx.beginPath();
-    ctx.moveTo(n[a][0]*w, n[a][1]*h);
-    ctx.lineTo(n[b][0]*w, n[b][1]*h);
+    ctx.moveTo(nodes[a][0] * w, nodes[a][1] * h);
+    ctx.lineTo(nodes[b][0] * w, nodes[b][1] * h);
     ctx.stroke();
   });
 
-  ctx.fillStyle = color;
-  nodes.forEach(([x,y]) => {
-
+  // nodes
   ctx.fillStyle = nodeColor;
-  n.forEach(([x,y]) => {
-
+  const r = Math.min(w, h) / NUM.THIRTYTHREE;
+  nodes.forEach(([nx, ny]) => {
     ctx.beginPath();
-    ctx.arc(x*w, y*h, NUM.ELEVEN/NUM.TWENTYTWO*6, 0, Math.PI*2); // gentle radius
+    ctx.arc(nx * w, ny * h, r, 0, Math.PI * 2);
     ctx.fill();
   });
+  ctx.restore();
 }
 
 // Layer 3 ---------------------------------------------------------------
 function drawFibonacci(ctx, w, h, color, NUM) {
-
-  /* Fibonacci logarithmic spiral approximated by polyline. */
-  const center = { x: w/NUM.THREE, y: h/NUM.THREE };
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = NUM.THREE;
-  const segs = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.SEVEN;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  for (let i = 0; i <= segs; i++) {
-    const t = (turns * 2 * Math.PI) * (i / segs);
-    const r = Math.pow(phi, t / (2*Math.PI));
-    const x = center.x + scale * r * Math.cos(t);
-    const y = center.y + scale * r * Math.sin(t);
-
-  /* Fibonacci spiral: static polyline using 144 samples.
-     ND-safe: single stroke. */
+  // Fibonacci logarithmic spiral sampled at 144 points
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
-  const phi = (1 + Math.sqrt(5)) / 2;
-
-  const turns = NUM.THREE;
-  const segs = NUM.ONEFORTYFOUR;
-
-  const center = { x: w/NUM.THREE, y: h/NUM.THREE };
+  const cx = w * 0.75;
+  const cy = h * 0.5;
+  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
+  const pts = NUM.ONEFORTYFOUR;
 
   ctx.beginPath();
-  for (let i = 0; i <= NUM.ONEFORTYFOUR; i++) {
-    const t = (i / NUM.ONEFORTYFOUR) * NUM.THREE * 2 * Math.PI;
-    const r = Math.pow(phi, t / (2*Math.PI));
-    const s = Math.min(w,h) / NUM.SEVEN;
-    const x = center.x + s * r * Math.cos(t);
-    const y = center.y + s * r * Math.sin(t);
-
+  for (let i = 0; i <= pts; i++) {
+    const theta = (i / pts) * Math.PI * 4;           // four turns
+    const r = scale * Math.exp(theta / NUM.ELEVEN);  // growth rate uses 11
+    const x = cx + r * Math.cos(theta);
+    const y = cy + r * Math.sin(theta);
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
+  ctx.restore();
 }
 
 // Layer 4 ---------------------------------------------------------------
-
-function drawHelix(ctx, w, h, color, NUM) {
-  /* Double-helix lattice: two static strands with cross rungs. */
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-
-  // strand A
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h/2 + Math.sin(t * waves * 2*Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  // strand B
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h/2 + Math.sin(t * waves * 2*Math.PI + Math.PI) * amp;
-
-
-function drawHelix(ctx, w, h, palette, NUM) {
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: no motion or flashing. */
-  ctx.save();
-  const amp = h / NUM.NINE;
-  const steps = NUM.NINETYNINE;
-  const turns = NUM.ELEVEN;
-  // strand A
-  ctx.strokeStyle = palette.layers[4];
-
 function drawHelix(ctx, w, h, strandColor, rungColor, NUM) {
-  /* Double-helix lattice: two phase-shifted sine strands with rungs.
-     ND-safe: static lines, no flashing. */
+  // Double-helix lattice: two phase-shifted sine strands with cross rungs
   ctx.save();
   const amp = h / NUM.NINE;
-  const turns = NUM.ELEVEN;
   const steps = NUM.NINETYNINE;
+  const turns = NUM.ELEVEN;
 
+  // strands
   ctx.lineWidth = 2;
   ctx.strokeStyle = strandColor;
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const x = (w / steps) * i;
-
-    const y = h/2 + Math.sin((i/steps) * Math.PI * turns) * amp;
+    const y = h / 2 + Math.sin((i / steps) * Math.PI * turns) * amp;
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
-  // strand B
+
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const x = (w / steps) * i;
-    const y = h/2 + Math.sin((i/steps) * Math.PI * turns + Math.PI) * amp;
-
+    const y = h / 2 + Math.sin((i / steps) * Math.PI * turns + Math.PI) * amp;
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
 
   // rungs
-
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= waves; i++) {
-    const t = i / waves;
-    const x = t * w;
-    const y1 = h/2 + Math.sin(t * waves * 2*Math.PI) * amp;
-    const y2 = h/2 + Math.sin(t * waves * 2*Math.PI + Math.PI) * amp;
-
-  ctx.strokeStyle = palette.layers[5];
+  ctx.strokeStyle = rungColor;
   ctx.lineWidth = 1;
   const rungs = NUM.THIRTYTHREE;
   for (let i = 0; i <= rungs; i++) {
     const x = (w / rungs) * i;
-    const y1 = h/2 + Math.sin((i/rungs) * Math.PI * turns) * amp;
-    const y2 = h/2 + Math.sin((i/rungs) * Math.PI * turns + Math.PI) * amp;
-
+    const phase = (i / rungs) * Math.PI * turns;
+    const y1 = h / 2 + Math.sin(phase) * amp;
+    const y2 = h / 2 + Math.sin(phase + Math.PI) * amp;
     ctx.beginPath();
     ctx.moveTo(x, y1);
     ctx.lineTo(x, y2);
     ctx.stroke();
-
-  }
-}
-
-
-
-    const y = h/2 + amp * Math.sin((i/steps) * turns * Math.PI * 2);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const x = (w / steps) * i;
-    const y = h/2 + amp * Math.sin((i/steps) * turns * Math.PI * 2 + Math.PI);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-  ctx.strokeStyle = rungColor;
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
-    const x = (w / NUM.THIRTYTHREE) * i;
-    const phase = (x / w) * turns * Math.PI * 2;
-    const y1 = h/2 + amp * Math.sin(phase);
-    const y2 = h/2 + amp * Math.sin(phase + Math.PI);
-    ctx.beginPath(); ctx.moveTo(x, y1); ctx.lineTo(x, y2); ctx.stroke();
-
   }
   ctx.restore();
 }
-
-
-


### PR DESCRIPTION
## Summary
- replace broken helix renderer with modular ND-safe ES module
- clean renderer docs and palette JSON
- update project task list to track renderer status

## Testing
- `node tools/dedupe.mjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4583dd0c832895cc26cfe4265b57