### PR TITLE
Add core node graphs and flow docs

### DIFF
--- a/graphs/core_node_map.json
+++ b/graphs/core_node_map.json
@@ -1,0 +1,121 @@
+{
+  "graphId": "cathedral-core-10",
+  "version": "1.0.0",
+  "layers": ["Art", "Science", "Magic", "Psychology", "Healing", "Technology", "Mythos"],
+  "nodes": [
+    {
+      "id": "tesla",
+      "kind": "room",
+      "name": "Nikola Tesla",
+      "domain": ["Science", "Technology", "Magic"],
+      "codexRole": "Tower disruptor / Lightning Master",
+      "tarotOverlay": "XVI The Tower",
+      "artifact": "Lightning Coil Plate"
+    },
+    {
+      "id": "hypatia",
+      "kind": "room",
+      "name": "Hypatia of Alexandria",
+      "domain": ["Science", "Art", "Mythos"],
+      "codexRole": "Garden guide / Star weaver",
+      "tarotOverlay": "XVII The Star",
+      "artifact": "Spiral Star Plate"
+    },
+    {
+      "id": "agrippa",
+      "kind": "room",
+      "name": "H. C. Agrippa",
+      "domain": ["Magic", "Mythos", "Psychology"],
+      "codexRole": "Seed scribe / Lattice architect",
+      "tarotOverlay": "I The Magician",
+      "artifact": "Seed Grid Plate"
+    },
+    {
+      "id": "dee",
+      "kind": "room",
+      "name": "John Dee",
+      "domain": ["Magic", "Science", "Mythos"],
+      "codexRole": "Magician-Navigator of Angelic Lattice",
+      "tarotOverlay": "I The Magician",
+      "artifact": "Monadic Plate"
+    },
+    {
+      "id": "fortune",
+      "kind": "room",
+      "name": "Dion Fortune",
+      "domain": ["Magic", "Psychology", "Healing"],
+      "codexRole": "Guardian of Inner Temple / Lady Chapel",
+      "tarotOverlay": "VIII Strength",
+      "artifact": "Rose Cross Plate"
+    },
+    {
+      "id": "hilma",
+      "kind": "room",
+      "name": "Hilma af Klint",
+      "domain": ["Art", "Healing", "Mythos"],
+      "codexRole": "Visionary Painter of Spiral Gardens",
+      "tarotOverlay": "XVIII The Moon",
+      "artifact": "Spiral Garden Plate"
+    },
+    {
+      "id": "witch-mods",
+      "kind": "faction",
+      "name": "Witch Mods",
+      "domain": ["Technology", "Magic", "Mythos"],
+      "codexRole": "Faction of Vigilance",
+      "tarotOverlay": "XI Justice",
+      "artifact": "Witch Eye Seal"
+    },
+    {
+      "id": "crowley-shadow",
+      "kind": "faction",
+      "name": "Crowley Shadow",
+      "domain": ["Magic", "Mythos"],
+      "codexRole": "Creative Risk / Disruption Agent",
+      "tarotOverlay": "XVI The Tower",
+      "artifact": "Lightning Tower Plate"
+    },
+    {
+      "id": "virelai",
+      "kind": "faction",
+      "name": "Rubescara / Virelai Ezra Lux",
+      "domain": ["Healing", "Art", "Magic"],
+      "codexRole": "Alchemist of Transmutation",
+      "tarotOverlay": "XIV Temperance",
+      "artifact": "Violet Flame Plate"
+    },
+    {
+      "id": "rebecca-respawn",
+      "kind": "faction",
+      "name": "Rebecca Respawn",
+      "domain": ["Mythos", "Psychology", "Healing"],
+      "codexRole": "Reset Gate / Pioneer",
+      "tarotOverlay": "0 The Fool",
+      "artifact": "Respawn Gate Plate"
+    }
+  ],
+  "edges": [
+    {"from": "tesla", "to": "crowley-shadow", "type": "amplifies", "note": "Lightning → Tower disruption"},
+    {"from": "crowley-shadow", "to": "rebecca-respawn", "type": "requiresReset", "note": "After collapse, respawn"},
+    {"from": "rebecca-respawn", "to": "fortune", "type": "seeksProtection", "note": "Stabilize after reset"},
+    {"from": "fortune", "to": "witch-mods", "type": "summons", "note": "Audit false glamour / parasitics"},
+    {"from": "witch-mods", "to": "tesla", "type": "tests", "note": "Integrity check on power systems"},
+
+    {"from": "agrippa", "to": "dee", "type": "influences", "note": "Correspondence grid → angelic lattice"},
+    {"from": "dee", "to": "hilma", "type": "inspires", "note": "Glyphs → visionary spiral diagrams"},
+    {"from": "hilma", "to": "virelai", "type": "feeds", "note": "Spiral art → violet transmutation"},
+    {"from": "virelai", "to": "fortune", "type": "fortifies", "note": "Violet flame supports psychic shield"},
+    {"from": "fortune", "to": "agrippa", "type": "grounds", "note": "Temple form anchors correspondence"},
+
+    {"from": "hypatia", "to": "agrippa", "type": "rationalizes", "note": "Math/logic clarifies tables"},
+    {"from": "hypatia", "to": "hilma", "type": "balances", "note": "Reason ⇄ vision"},
+    {"from": "tesla", "to": "hypatia", "type": "harmonizes", "note": "Frequency meets number"},
+    {"from": "witch-mods", "to": "crowley-shadow", "type": "checks", "note": "Ethical watch on disruption"},
+    {"from": "rebecca-respawn", "to": "witch-mods", "type": "authorizes", "note": "Witch Eye brand covenant"},
+
+    {"from": "dee", "to": "tesla", "type": "bridges", "note": "Monadic geometry → wireless lattice"},
+    {"from": "agrippa", "to": "tesla", "type": "maps", "note": "Planetary tables to coils"},
+    {"from": "virelai", "to": "rebecca-respawn", "type": "heals", "note": "Violet flame restores nerve after trials"},
+    {"from": "crowley-shadow", "to": "fortune", "type": "provokes", "note": "Forces better shielding design"}
+  ]
+}

--- a/graphs/navigation_rules.json
+++ b/graphs/navigation_rules.json
@@ -1,0 +1,34 @@
+{
+  "graphId": "cathedral-core-10",
+  "rulesVersion": "1.0.0",
+  "edgeBehaviors": {
+    "amplifies": {"onEnter": ["increaseIntensity:lightning", "spawnEvent:towerShock"], "onExit": []},
+    "requiresReset": {"onEnter": ["callFaction:rebecca-respawn", "enableRespawn:true"], "onExit": []},
+    "seeksProtection": {"onEnter": ["callFaction:fortune", "grant:shield:rose-cross"], "onExit": []},
+    "summons": {"onEnter": ["callFaction:witch-mods", "perform:glamourAudit"], "onExit": []},
+    "tests": {"onEnter": ["challenge:integrityCheck"], "onExit": []},
+
+    "influences": {"onEnter": ["boost:correspondenceAccuracy"], "onExit": []},
+    "inspires": {"onEnter": ["open:visionaryChannel"], "onExit": []},
+    "feeds": {"onEnter": ["charge:violetFlame"], "onExit": []},
+    "fortifies": {"onEnter": ["reinforce:psychicShield"], "onExit": []},
+    "grounds": {"onEnter": ["apply:templeFormConstraints"], "onExit": []},
+
+    "rationalizes": {"onEnter": ["enforce:logicCheck"], "onExit": []},
+    "balances": {"onEnter": ["equalize:leftRightBrain"], "onExit": []},
+    "harmonizes": {"onEnter": ["tune:frequencyToNumber"], "onExit": []},
+    "checks": {"onEnter": ["audit:ethicalUseOfDisruption"], "onExit": []},
+    "authorizes": {"onEnter": ["seal:witchEyeBrand"], "onExit": []},
+
+    "bridges": {"onEnter": ["link:geometryToLattice"], "onExit": []},
+    "maps": {"onEnter": ["translate:tablesToHardware"], "onExit": []},
+    "heals": {"onEnter": ["restore:nervousSystem", "reduce:overwhelm"], "onExit": []},
+    "provokes": {"onEnter": ["stressTest:shield"], "onExit": []}
+  },
+  "safety": {
+    "respawnEnabled": true,
+    "noAutoplay": true,
+    "gatedAudio": true,
+    "maxIntensity": 0.85
+  }
+}

--- a/graphs/render_hints.json
+++ b/graphs/render_hints.json
@@ -1,0 +1,65 @@
+{
+  "graphId": "cathedral-core-10",
+  "renderHints": {
+    "tesla": {
+      "harmonics": ["396Hz", "528Hz"],
+      "palette": ["#B8F3FF", "#FFD340", "#110F20"],
+      "crystal": "pyrite-coil",
+      "geometry": ["zigzag-lightning", "coil-helix"]
+    },
+    "hypatia": {
+      "harmonics": ["639Hz", "741Hz"],
+      "palette": ["#D8E6FF", "#7DA0D4", "#1F2C48"],
+      "crystal": "sodalite-icosa",
+      "geometry": ["golden-spiral", "astral-grid"]
+    },
+    "agrippa": {
+      "harmonics": ["432Hz", "285Hz"],
+      "palette": ["#C0B08D", "#2D2314", "#EEE6C9"],
+      "crystal": "hematite-cube",
+      "geometry": ["soyga-square", "planetary-sigils"]
+    },
+    "dee": {
+      "harmonics": ["528Hz", "852Hz"],
+      "palette": ["#E0FFE8", "#355C43", "#0D1E13"],
+      "crystal": "emerald-octagon",
+      "geometry": ["monas-glyph", "angelic-lattice"]
+    },
+    "fortune": {
+      "harmonics": ["417Hz", "528Hz"],
+      "palette": ["#FCE7F0", "#C2255C", "#1A0C14"],
+      "crystal": "rose-quartz-cross",
+      "geometry": ["rose-cross", "temple-grid"]
+    },
+    "hilma": {
+      "harmonics": ["963Hz", "432Hz"],
+      "palette": ["#F6F0FF", "#A77BD1", "#2E1042"],
+      "crystal": "amethyst-flower",
+      "geometry": ["concentric-rings", "swan-curve"]
+    },
+    "witch-mods": {
+      "harmonics": ["741Hz"],
+      "palette": ["#0E1116", "#3FFFD7", "#F6FF52"],
+      "crystal": "obsidian-eye",
+      "geometry": ["watchful-eye", "hex-mesh"]
+    },
+    "crowley-shadow": {
+      "harmonics": ["396Hz"],
+      "palette": ["#1A0C14", "#FF2E63", "#FFD340"],
+      "crystal": "meteorite-frag",
+      "geometry": ["fracture-planes", "tower-strike"]
+    },
+    "virelai": {
+      "harmonics": ["528Hz", "639Hz"],
+      "palette": ["#9B59B6", "#E8D3FF", "#FFF8E6"],
+      "crystal": "ametrine-prism",
+      "geometry": ["violet-flame", "temperance-flow"]
+    },
+    "rebecca-respawn": {
+      "harmonics": ["256Hz", "432Hz"],
+      "palette": ["#FFFFFF", "#C7C7FF", "#121212"],
+      "crystal": "moonstone-disc",
+      "geometry": ["ouroboros-circuit", "respawn-ring"]
+    }
+  }
+}

--- a/graphs/ui_flow.md
+++ b/graphs/ui_flow.md
@@ -1,0 +1,24 @@
+# Core 10 Node Flow (Player-Facing)
+
+1) Enter **Tesla** → Lightning test (Tower energy).
+   - If overwhelmed → auto-call **Rebecca Respawn** (reset).
+   - Pass → gain **Lightning Coil Plate**.
+
+2) Route to **Fortune** → Shield lesson.
+   - Witch Mods run a glamour audit.
+   - Pass → gain **Rose Cross Plate**.
+
+3) Split path:
+   - **Agrippa** → learn correspondence lattice → craft **Seed Grid Plate**.
+   - **Dee** → open angelic navigation → craft **Monadic Plate**.
+
+4) Vision branch:
+   - **Hypatia** ↔ **Hilma** balance reason & vision.
+   - Fuse plates → unlock **Spiral Garden Plate** (healing visual).
+
+5) Faction dynamics:
+   - **Crowley Shadow** stress-tests structures.
+   - **Virelai** repairs with Violet Flame.
+   - **Witch Mods** seal project with **Witch Eye**.
+
+→ All artifacts archive into **Codex 144:99** lattice; available across apps.


### PR DESCRIPTION
## Summary
- Add core node map describing nodes, edges, and domains
- Define navigation rules and render hints for Cathedral Core 10
- Document player-facing node flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be8dd2eb848328a33828e188ae3d62