### PR TITLE
doc: add ritual and study anchors

### DIFF
--- a/RITUAL_MAP.md
+++ b/RITUAL_MAP.md
@@ -1,0 +1,59 @@
+# Ritual and Study Anchors
+
+Map of ritual and study anchors grounded in source texts. Each lineage offers practices and play hooks for the double Tree / 72 Shem traversal.
+
+## Aleister Crowley (Thelema)
+- **Texts**: *Liber AL vel Legis* (Book of the Law).
+- **Practices**: Daily recitation of the "Do what thou wilt" formula; pathworking through Horus' Aeon.
+- **Rituals**: Star Ruby (banishing), Star Sapphire (invocation), Mass of the Phoenix, Gnostic Mass.
+- **Play integration**: Rituals act as save points or transformation gates. The Aeonic spiral aligns with the Fool → Magus threshold.
+
+## Stephen Skinner (Geomancy & Angel Magic)
+- **Texts**: *Practical Angel Magic* drawing on Dee's Enochian Tables.
+- **Practices**: Structured calls to angels, kings, and elemental seniors.
+- **Geomancy**: Sixteen binary figures tied to planetary intelligences and fates.
+- **Play integration**: Figures generate procedural floorplans; angelic invocations unlock upper ladders of Jacob's Tree.
+
+## Splendor Solis (via Skinner's edition)
+- **Texts**: Alchemical plates illustrating the Magnum Opus stages.
+- **Practices**: Meditative visualization and ritual bath for each color-stage: nigredo, albedo, citrinitas, rubedo.
+- **Play integration**: Each alchemical phase forms a realm players must endure, transform, and ascend through.
+
+## Frater U∴D∴ (Sigil & Chaos Magic)
+- **Texts**: *Practical Sigil Magic*.
+- **Practices**: Creation of glyphs charged via gnosis (trance, dance, silence).
+- **Play integration**: Players craft sigils in an art lab then charge them to activate perks or shift narratives. Archetype: the Chaos Magician as Fool turned Trickster.
+
+## Goetia of Dr. Rudd (Skinner/Rankine)
+- **Texts**: Dual catalog of 72 spirits and Shem angels.
+- **Practices**: Evocation using divine names and angelic seals.
+- **Play integration**: Each chapter pairs an angel-demon encounter. The Tarot avatar chooses to bind, banish, or integrate.
+
+## Dion Fortune
+- **Texts**: *The Mystical Qabalah*, *Cosmic Doctrine*, *Psychic Self-Defense*.
+- **Practices**: Sephirothic pathworkings, visualization, and protective circles or veils.
+- **Play integration**: Seals and psychic hygiene mechanics guard higher Tree paths; spiral cosmogenesis guides labyrinth design.
+
+## Paul Foster Case
+- **Texts**: B.O.T.A. lessons and Cube of Space meditations.
+- **Practices**: Letter correspondences where each Hebrew glyph becomes a gate.
+- **Play integration**: Color-tone blending puzzles aid ascent through the Sephiroth; Temperance functions as an NPC fusion angel.
+
+## David Rankine & Stephen Skinner (Arthur Gauntlet & Solomonic)
+- **Texts**: Practical prayers and bindings using Trinitarian seals and saintly invocations.
+- **Practices**: Medieval Christian magic pathways.
+- **Play integration**: Side-realms display syncretic Western esoteric lineages.
+
+## Fusion Design
+- **Double Tree Game Spine**: Each chapter combines an alchemical stage, an angel/demon duel, and one lineage practice.
+- **NPC Archetypes**: Angels, demons, Taras, priests, and adepts act as helpers or testers.
+- **Playable Tarot Avatars**: Fool → World, each with unique strengths and weaknesses in rituals.
+- **Ritual Puzzles**:
+  - Crowley: banish/invoke gates.
+  - Fortune: seals and psychic hygiene.
+  - Case: color-tone blending.
+  - Skinner: Enochian angel grid puzzles.
+  - Goetia: dual binding challenges.
+  - Splendor Solis: alchemical ordeal stages.
+
+This map serves as a fusion engine of real spells, archetypes, and practices—scalable into worlds, discovery rooms, and research labs.


### PR DESCRIPTION
## Summary
- document key ritual and study anchors from multiple esoteric lineages
- outline integration hooks for double Tree/72 Shem traversal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c11477e9d88328b960b07dbe4e6f90