### PR TITLE
feat: add static helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,32 +1,11 @@
 Per Texturas Numerorum, Spira Loquitur.
-Per Texturas Numerorum, Spira Loquitur. //
 
 # Cosmic Helix Renderer
 
 Static, offline canvas demo for layered sacred geometry. No build step, no network calls, ND-safe by design.
 
 ## Layers
-1. **Vesica field** — intersecting circles seed the grid (3,7,9)
-2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths
-3. **Fibonacci curve** — logarithmic spiral using 144 sampled points
-4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs
-1. **Vesica field** — intersecting circles seed the grid (constants 3,7,9).
-2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths.
-3. **Fibonacci curve** — logarithmic spiral using 144 sampled points.
-4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs.
-1. **Vesica field** (R001) - intersecting circles seed the grid (constants 3,7,9).
-2. **Tree-of-Life scaffold** (R002) - 10 nodes and 22 connective paths.
-3. **Fibonacci curve** (R003) - logarithmic spiral using 144 sampled points.
-4. **Double-helix lattice** (R004) - two phase-shifted strands with 33 cross rungs.
-1. **Vesica field** - intersecting circles seed the grid (3, 7, 9).
-2. **Tree-of-Life scaffold** - 10 nodes with 22 connective paths.
-3. **Fibonacci curve** - logarithmic spiral using 144 sampled points.
-4. **Double-helix lattice** - two phase-shifted strands with 33 cross rungs.
 1. **Vesica field** — intersecting circles seed the grid (3, 7, 9).
-2. **Tree-of-Life scaffold** — 10 nodes with 22 paths.
-3. **Fibonacci curve** — logarithmic spiral using 144 sampled points.
-4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs.
-1. **Vesica field** — intersecting circles seed the grid (constants 3, 7, 9).
 2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths.
 3. **Fibonacci curve** — logarithmic spiral using 144 sampled points.
 4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs.
@@ -35,29 +14,10 @@ Static, offline canvas demo for layered sacred geometry. No build step, no netwo
 - Open `index.html` directly in any modern browser.
 - Optional: edit `data/palette.json` to change colors; if missing, a calm fallback palette is used and the header shows a notice.
 
-## Fallback behavior
-If `data/palette.json` is absent or malformed, the renderer announces the missing palette and uses a built-in calm palette. This guards against harsh defaults while staying fully offline.
-
 ## ND-safe choices
 - No animation, autoplay, or flashing.
 - Gentle contrast with readable inks on dark background.
 - Layer order preserves depth without motion.
 
 ## Numerology constants
-Constants exposed in `index.html` as `NUM` feed the renderer: 3, 7, 9, 11, 22, 33, 99, 144.
-
-The renderer uses constants that echo Tarot and Fibonacci harmonics: 3, 7, 9, 11, 22, 33, 99, 144.
-
-## Numerology as spiral grammar
-
-The wider cathedral runs on spiral invariants:
-The wider cathedral runs on spiral invariants: numbers that echo Fibonacci and Tarot harmonics.
-
-- 21 pillars: Fibonacci step (8 + 13) aligned with major arcana and the 21 Taras.
-- 33 spine: 3 x 11 initiatory vertebrae; a Christic ladder of balance.
-- 72 Shem angels/demons: 8 x 9 lunar decans; sacred multiple of 12.
-- 78 archetypes: Tarot deck complete (22 majors + 56 minors) woven into one continuum.
-- 99 gates: 3 x 33 triplicity opening to recursive paths.
-- 144 lattice: Fibonacci square (12^2) supporting the codex itself.
-- 243 completion: 3^5 cube of balance sealing the cathedral.
-Constants exposed in `index.html` as `NUM` feed the geometry: 3, 7, 9, 11, 22, 33, 99, 144.
+The renderer uses constants that echo Fibonacci and Tarot harmonics: 3, 7, 9, 11, 22, 33, 99, 144.

--- a/data/palette.json
+++ b/data/palette.json
@@ -2,12 +2,4 @@
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
   "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-  "layers": [
-    "#b1c7ff",
-    "#89f7fe",
-    "#a0ffa1",
-    "#ffd27f",
-    "#f5a3ff",
-    "#d0d0e6"
-  ]
 }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -18,7 +18,7 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette...</div>
   </header>
 

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -2,54 +2,13 @@
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-  Layers:
-    1) Vesica field – intersecting circles forming a calm grid
-    2) Tree-of-Life scaffold – 10 sephirot nodes + 22 paths
-    3) Fibonacci curve – logarithmic spiral polyline
-    4) Double-helix lattice – two phase-shifted strands with 33 rungs
-    3) Fibonacci curve – logarithmic spiral approximated by polyline
-    4) Double-helix lattice – two static strands with 33 cross rungs
-    1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 nodes + 22 paths)
-    3) Fibonacci curve (log spiral polyline)
-    4) Double-helix lattice (two phase-shifted strands with rungs)
-  Layers (drawn in order):
-    1) Vesica field — intersecting circles forming a calm grid
-    2) Tree-of-Life scaffold — 10 sephirot nodes + 22 connecting paths
-    3) Fibonacci curve — logarithmic spiral approximated by polyline
-    4) Double-helix lattice — two phase-shifted strands with 33 cross rungs
-  Layers (drawn in order):
-    1) Vesica field - intersecting circles forming a calm grid
-    2) Tree-of-Life scaffold - 10 sephirot nodes + 22 connecting paths
-    3) Fibonacci curve - logarithmic spiral approximated by polyline
-    4) Double-helix lattice - two phase-shifted strands with 33 cross rungs
-  Layers drawn in order:
-    1) Vesica field – intersecting circles
-    2) Tree-of-Life scaffold – 10 sephirot nodes + 22 paths
-    3) Fibonacci curve – logarithmic spiral polyline
-    4) Double-helix lattice – two phase-shifted strands with 33 rungs
+  Layers (rendered in order):
+    1) Vesica field — intersecting circles
+    2) Tree-of-Life scaffold — 10 nodes with 22 paths
+    3) Fibonacci curve — logarithmic spiral polyline
+    4) Double-helix lattice — two phase-shifted strands with rungs
 
   All functions are pure and run once; no motion, no dependencies.
-*/
-
-export function renderHelix(ctx, { width, height, palette, NUM }) {
-  // Prepare stage
-  // wipe canvas
-  Layers (drawn in order):
-    1) Vesica field - intersecting circles forming a calm grid (R001)
-    2) Tree-of-Life scaffold - 10 nodes & 22 paths (R002)
-    3) Fibonacci curve - logarithmic spiral sampled (R003)
-    4) Double-helix lattice - two static strands with cross rungs (R004)
-
-  No animation, no external dependencies.
-*/
-
-export function renderHelix(ctx, { width, height, palette, NUM }) {
-    2) Tree-of-Life scaffold – 10 sephirot nodes with 22 paths
-    3) Fibonacci curve – logarithmic spiral using 144 samples
-    4) Double-helix lattice – two phase-shifted strands with rungs
-
-  Design: no motion, no external deps, ASCII quotes only.
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
@@ -57,15 +16,6 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  // layer order preserves depth without motion
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, {
-    a: palette.layers[4],
-    b: palette.layers[5],
-    rung: palette.ink
-  }, NUM);
   drawVesica(ctx, width, height, palette.layers[0], NUM);
   drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
   drawFibonacci(ctx, width, height, palette.layers[3], NUM);
@@ -74,57 +24,15 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.restore();
 }
 
-/* Layer 1: Vesica field (C144N-001..144) */
+/* Layer 1: Vesica field — calm grid of intersecting circles */
 function drawVesica(ctx, w, h, color, NUM) {
-  // ND-safe: thin strokes, generous spacing
+  const r = Math.min(w, h) / NUM.THREE; // triadic radius
+  const step = r / NUM.SEVEN;           // septenary spacing
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 1;
-  /* Vesica field: calm outline grid built from overlapping circles.
-     ND-safe: thin lines, generous spacing. */
-  const r = Math.min(w, h) / NUM.THREE; // base radius from sacred triad
-  const step = r / NUM.SEVEN;           // spacing guided by 7
-  // ND-safe: thin lines, generous spacing, no motion
-  const r = Math.min(w, h) / NUM.THREE;      // triadic radius
-  const step = r / NUM.SEVEN;                // septenary spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  // ND-safe: thin lines, generous spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  const r = Math.min(w, h) / NUM.THREE;
-  const step = r / NUM.SEVEN;
   for (let y = r; y < h; y += step * NUM.NINE) {
     for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
-      ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
-/* Layer 1: Vesica field */
-function drawVesica(ctx, w, h, color, NUM) {
-  // ND-safe: thin lines, generous spacing
-/* Layer 1: Vesica field --------------------------------------------------- */
-function drawVesica(ctx, w, h, color, NUM) {
-  /* Vesica field: calm outline grid built from overlapping circles.
-     ND-safe: thin lines, generous spacing. */
-  const r = Math.min(w, h) / NUM.THREE;      // base radius from sacred triad
-  const step = r / NUM.SEVEN;                // spacing guided by 7
-  // Vesica field: calm outline grid; ND-safe thin strokes
-  const r = Math.min(w, h) / NUM.THREE;      // triadic radius
-  const step = r / NUM.SEVEN;                // septenary spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  const r = Math.min(w, h) / NUM.THREE;      // triadic radius
-  const step = r / NUM.SEVEN;                // septenary spacing
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
       ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
       ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
     }
@@ -132,114 +40,29 @@ function drawVesica(ctx, w, h, color, NUM) {
   ctx.restore();
 }
 
-/* Layer 2: Tree-of-Life scaffold (C144N-001..010, 22 paths) */
+/* Layer 2: Tree-of-Life scaffold — 10 nodes, 22 paths */
 function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  // ND-safe: static nodes and paths, no glow
-  ctx.save();
-  const layout = [
-    { x: 0.5, y: 0.05 }, // Kether
-    { x: 0.75, y: 0.18 }, // Chokmah
-    { x: 0.25, y: 0.18 }, // Binah
-    { x: 0.75, y: 0.35 }, // Chesed
-    { x: 0.25, y: 0.35 }, // Geburah
-    { x: 0.5, y: 0.5 },   // Tiphereth
-    { x: 0.75, y: 0.65 }, // Netzach
-    { x: 0.25, y: 0.65 }, // Hod
-    { x: 0.5, y: 0.78 },  // Yesod
-    { x: 0.5, y: 0.95 }   // Malkuth
-  ].map(n => ({ x: n.x * w, y: n.y * h }));
-
-  const edges = [
-    [0,1],[0,2],[0,5],
-    [1,2],[1,3],[1,4],
-    [2,3],[2,4],[3,4],
-    [3,5],[3,6],[4,5],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,7],[6,8],[6,9],
-    [7,8],[7,9],[8,9]
-  /* Tree: 10 nodes with 22 connecting paths.
-     ND-safe: static points and lines, no flicker. */
   const nodes = [
-    { x:0.5, y:0.05 }, { x:0.75, y:0.15 }, { x:0.25, y:0.15 },
-    { x:0.75, y:0.35 }, { x:0.25, y:0.35 }, { x:0.5, y:0.45 },
-    { x:0.75, y:0.65 }, { x:0.25, y:0.65 }, { x:0.5, y:0.75 },
-    { x:0.5, y:0.9 }
-  ];
-  const paths = [
-    [0,1],[0,2],[1,2],[1,3],[1,5],[2,4],[2,5],[3,4],[3,5],[3,6],
-    [4,5],[4,7],[5,6],[5,7],[5,8],[6,7],[6,8],[7,8],[6,9],[7,9],[8,9],[0,5]
-  ];
-  const r = Math.min(w, h) / NUM.ELEVEN;
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  for (const [a,b] of edges) {
-    ctx.beginPath();
-    ctx.moveTo(layout[a].x, layout[a].y);
-    ctx.lineTo(layout[b].x, layout[b].y);
-    ctx.stroke();
-  }
+    [0.5, 0.05],
+    [0.25, 0.15], [0.75, 0.15],
+    [0.25, 0.3], [0.5, 0.35], [0.75, 0.3],
+    [0.25, 0.5], [0.75, 0.5],
+    [0.5, 0.6],
+    [0.5, 0.8]
+  ].map(([x, y]) => [x * w, y * h]);
 
-  ctx.fillStyle = nodeColor;
-  const r = h / NUM.TWENTYTWO;
-  for (const n of layout) {
-    ctx.beginPath();
-    ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
-  for (const [a,b] of paths) {
-    const p1 = nodes[a], p2 = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(p1.x * w, p1.y * h);
-    ctx.lineTo(p2.x * w, p2.y * h);
-    ctx.stroke();
-  }
-  ctx.fillStyle = nodeColor;
-  for (const p of nodes) {
-    ctx.beginPath();
-    ctx.arc(p.x * w, p.y * h, r, 0, Math.PI * 2);
-    ctx.fill();
-  }
-    [0.5, 0.05],[0.2,0.2],[0.8,0.2],[0.2,0.4],[0.8,0.4],
-    [0.5,0.5],[0.2,0.7],[0.8,0.7],[0.5,0.85],[0.5,0.95]
-  ];
   const paths = [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,5],[4,5],
-    [3,6],[4,7],[5,6],[5,7],[6,8],[7,8],[8,9],
-    [1,4],[2,3],[1,5],[2,6],[3,8],[4,8],[5,9],[6,9]
-  ].slice(0, NUM.TWENTYTWO);
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  for (const [a,b] of paths) {
-    const p1 = nodes[a], p2 = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(nodes[a][0]*w, nodes[a][1]*h);
-    ctx.lineTo(nodes[b][0]*w, nodes[b][1]*h);
-    ctx.stroke();
-  });
-  ctx.fillStyle = color;
-  const r = w / NUM.NINETYNINE;
-  nodes.forEach(([nx, ny]) => {
-    ctx.beginPath();
-    ctx.arc(nx*w, ny*h, r, 0, Math.PI*2);
-  ctx.save();
-  const nodes = [
-    [w/2, h*0.09],            // 0 Kether
-    [w*0.35, h*0.2], [w*0.65, h*0.2], // 1 Chokmah, 2 Binah
-    [w*0.35, h*0.35], [w*0.65, h*0.35], // 3 Chesed, 4 Geburah
-    [w/2, h*0.47],            // 5 Tiphereth
-    [w*0.35, h*0.6], [w*0.65, h*0.6], // 6 Netzach, 7 Hod
-    [w/2, h*0.75],            // 8 Yesod
-    [w/2, h*0.9]              // 9 Malkuth
+    [0,1],[0,2],
+    [1,2],[1,3],[1,4],[2,4],[2,5],
+    [3,4],[4,5],
+    [3,6],[4,6],[4,7],[5,7],
+    [6,8],[7,8],
+    [6,9],[7,9],
+    [8,9],
+    [3,5],[1,5],[2,3],[6,7]
   ];
-  const paths = [
-    [0,1],[0,2],[0,5],
-    [1,2],[1,3],[1,5],[2,4],[2,5],
-    [3,4],[3,5],[3,6],[4,5],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,7],[6,8],[6,9],
-    [7,8],[7,9],
-    [8,9]
-  ];
+
+  ctx.save();
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 1;
   paths.forEach(([a,b]) => {
@@ -248,400 +71,69 @@ function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
     ctx.lineTo(nodes[b][0], nodes[b][1]);
     ctx.stroke();
   });
-  const r = h / NUM.THIRTYTHREE; // gentle node radius
-  ctx.fillStyle = nodeColor;
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.moveTo(p1.x * w, p1.y * h);
-    ctx.lineTo(p2.x * w, p2.y * h);
-    ctx.stroke();
-  }
-  ctx.fillStyle = nodeColor;
-  for (const p of nodes) {
-    ctx.beginPath();
-    ctx.arc(p.x * w, p.y * h, r, 0, Math.PI * 2);
-  const nodes = [
-    [0.5, 0.05],  // 1 Keter
-    [0.75, 0.18], // 2 Chokmah
-    [0.25, 0.18], // 3 Binah
-    [0.75, 0.38], // 4 Chesed
-    [0.25, 0.38], // 5 Geburah
-    [0.5, 0.50],  // 6 Tiphareth
-    [0.75, 0.62], // 7 Netzach
-    [0.25, 0.62], // 8 Hod
-    [0.5, 0.74],  // 9 Yesod
-    [0.5, 0.88]   //10 Malkuth
-  ];
-  const edges = [
-    [0,1],[0,2],[1,3],[2,4],[3,5],[4,5],[5,6],[3,6],[4,6],
-    [3,7],[4,8],[7,8],[7,9],[8,9],[6,7],[6,8],[6,9],[7,10],
-    [8,10],[9,10],[5,9],[5,7]
-  ];
-
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  for (const [a, b] of edges) {
-    const [x1, y1] = nodes[a];
-    const [x2, y2] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(x1 * w, y1 * h);
-    ctx.lineTo(x2 * w, y2 * h);
-    ctx.stroke();
-  }
 
   ctx.fillStyle = nodeColor;
   const r = Math.min(w, h) / NUM.TWENTYTWO;
-  for (const [x, y] of nodes) {
-    ctx.beginPath();
-    ctx.arc(x * w, y * h, r, 0, Math.PI * 2);
-  // ND-safe: static scaffold, no motion
-  const nodes = [];
-  const colX = [
-    w / NUM.THREE,
-    w / 2,
-    w - w / NUM.THREE
-  ];
-  const rowY = [];
-  for (let i = 1; i <= NUM.NINE; i++) {
-    rowY.push((h / (NUM.NINE + 1)) * i);
-  }
-  // simplified 10 sephirot layout
-  nodes.push({ x: colX[1], y: rowY[0] }); // Keter
-  nodes.push({ x: colX[0], y: rowY[1] }); // Chokmah
-  nodes.push({ x: colX[2], y: rowY[1] }); // Binah
-  nodes.push({ x: colX[0], y: rowY[2] }); // Chesed
-  nodes.push({ x: colX[2], y: rowY[2] }); // Geburah
-  nodes.push({ x: colX[1], y: rowY[3] }); // Tiferet
-  nodes.push({ x: colX[0], y: rowY[4] }); // Netzach
-  nodes.push({ x: colX[2], y: rowY[4] }); // Hod
-  nodes.push({ x: colX[1], y: rowY[5] }); // Yesod
-  nodes.push({ x: colX[1], y: rowY[7] }); // Malkuth
-
-  const paths = [
-    [0,1],[0,2],[1,3],[1,5],[2,4],[2,5],
-    [3,4],[3,5],[4,5],[3,6],[4,7],[6,7],
-    [6,8],[7,8],[5,8],[8,9]
-  ];
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 2;
-  for (const [a,b] of paths) {
-    const A = nodes[a], B = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(A.x, A.y);
-    ctx.lineTo(B.x, B.y);
-    ctx.stroke();
-  }
-  ctx.fillStyle = nodeColor;
-  const r = Math.min(w, h) / NUM.NINETYNINE * NUM.THREE; // small node radius
-  for (const n of nodes) {
-    ctx.beginPath();
-    ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------ */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  /* Tree-of-Life: 10 sephirot and 22 paths.
-     ND-safe: static nodes, no glow, readable contrast. */
-  const stepY = h / NUM.TWENTYTWO;
-  const xL = w / NUM.THREE;             // left pillar
-  const xR = w - xL;                    // right pillar
-  const xC = w / 2;                     // middle pillar
-  const nodes = [
-    [xC, stepY],            // 0 Keter
-    [xL, stepY * 3],        // 1 Chokmah
-    [xR, stepY * 3],        // 2 Binah
-    [xL, stepY * 6],        // 3 Chesed
-    [xR, stepY * 6],        // 4 Gevurah
-    [xC, stepY * 8],        // 5 Tiferet
-    [xL, stepY * 11],       // 6 Netzach
-    [xR, stepY * 11],       // 7 Hod
-    [xC, stepY * 13],       // 8 Yesod
-    [xC, stepY * 16]        // 9 Malkuth
-  ];
-  const edges = [
-    [0,1],[0,2],[1,2],
-    [1,3],[1,5],[1,4],
-    [2,4],[2,5],[2,3],
-    [3,5],[3,6],[3,8],
-    [4,5],[4,7],[4,8],
-    [5,6],[5,7],[5,8],
-    [6,7],[6,8],[7,8],
-    [8,9]
-  ];
-
-  ctx.save();
-  // paths
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1.5;
-  edges.forEach(([a,b]) => {
-    const [x1,y1] = nodes[a];
-    const [x2,y2] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(x1,y1);
-    ctx.lineTo(x2,y2);
-    ctx.stroke();
-  });
-
-  // nodes
-  const r = h / NUM.NINETYNINE * 4;
-  ctx.fillStyle = nodeColor;
   nodes.forEach(([x,y]) => {
     ctx.beginPath();
     ctx.arc(x, y, r, 0, Math.PI * 2);
-/* Layer 2: Tree-of-Life scaffold */
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  // Simplified 10-node tree with 22 connective paths
-  ctx.save();
-  const r = Math.min(w, h) / NUM.THIRTYTHREE; // node radius guided by 33
-  const nodes = [
-    { x:0.5, y:0.05 },
-    { x:0.5, y:0.18 },
-    { x:0.35, y:0.26 },
-    { x:0.65, y:0.26 },
-    { x:0.35, y:0.40 },
-    { x:0.65, y:0.40 },
-    { x:0.5, y:0.48 },
-    { x:0.35, y:0.64 },
-    { x:0.65, y:0.64 },
-    { x:0.5, y:0.82 }
-  ];
-  const paths = [
-    [0,1],[1,2],[1,3],[2,4],[3,5],[4,6],[5,6],[4,7],[5,8],
-    [7,8],[7,9],[8,9],[2,3],[0,2],[0,3],[6,7],[6,8],[1,6],
-    [6,9],[4,5],[2,5],[3,4]
-  ];
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  for (const [a,b] of paths) {
-    const A = nodes[a], B = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(A.x * w, A.y * h);
-    ctx.lineTo(B.x * w, B.y * h);
-    ctx.stroke();
-  }
-  ctx.fillStyle = nodeColor;
-  for (const n of nodes) {
-    ctx.beginPath();
-    ctx.arc(n.x * w, n.y * h, r, 0, Math.PI * 2);
     ctx.fill();
-  }
+  });
   ctx.restore();
 }
 
-/* Layer 3: Fibonacci curve */
+/* Layer 3: Fibonacci curve — static logarithmic spiral */
 function drawFibonacci(ctx, w, h, color, NUM) {
-  // ND-safe: static spiral, 144 samples
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  const cx = w * 0.3;
-  const cy = h * 0.6;
-  const pts = NUM.ONEFORTYFOUR;
   const phi = (1 + Math.sqrt(5)) / 2;
-  ctx.beginPath();
-  for (let i = 0; i < pts; i++) {
-    const theta = 0.1 * i;
-    const rad = Math.pow(phi, theta / Math.PI);
-    const x = cx + rad * Math.cos(theta) * 20;
-    const y = cy + rad * Math.sin(theta) * 20;
-  /* Fibonacci spiral: 144 sample points with golden ratio growth.
-     ND-safe: soft stroke, no animation. */
-  const cx = w * 0.2;  // start near left for spacious curve
-  const cy = h * 0.8;
-  const points = NUM.ONEFORTYFOUR;
-  const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
-  /* Fibonacci spiral: static logarithmic curve.
-     ND-safe: single line, no animation. */
-  const center = { x: w/NUM.THREE, y: h/NUM.THREE };
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = NUM.THREE;
-  const segs = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.SEVEN;
-/* Layer 3: Fibonacci curve (R003) */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  // Log spiral using golden ratio, 144 samples
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const points = [];
-  const scale = Math.min(w, h) / NUM.TWENTYTWO;
-  for (let i = 0; i < NUM.ONEFORTYFOUR; i++) {
-    const angle = i * (Math.PI / NUM.NINE);
-    const radius = scale * Math.pow(phi, i / NUM.TWENTYTWO);
-    const x = w/2 + radius * Math.cos(angle);
-    const y = h/2 + radius * Math.sin(angle);
-    points.push([x, y]);
-  }
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  for (let i = 0; i < points; i++) {
-    const angle = i / NUM.TWENTYTWO * Math.PI * 2;
-    const radius = scale * Math.pow(phi, i / NUM.TWENTYTWO);
-    const x = cx + Math.cos(angle) * radius;
-    const y = cy - Math.sin(angle) * radius;
-  for (let i = 0; i <= segs; i++) {
-    const t = (turns * 2 * Math.PI) * (i / segs);
-    const r = Math.pow(phi, t / (2 * Math.PI));
-    const x = center.x + scale * r * Math.cos(t);
-    const y = center.y + scale * r * Math.sin(t);
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  const points = NUM.ONEFORTYFOUR;
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const scale = Math.min(w, h) / NUM.TWENTYTWO;
-  ctx.beginPath();
-  for (let i = 0; i < points; i++) {
-    const t = i / points * NUM.TWENTYTWO;
-    const r = scale * Math.pow(phi, t / NUM.ELEVEN);
-    const ang = t * Math.PI / NUM.ELEVEN;
-    const x = w/2 + r * Math.cos(ang);
-    const y = h/2 + r * Math.sin(ang);
-  // ND-safe: static spiral with 144 samples
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci spiral: logarithmic curve with 144 samples.
-     ND-safe: single stroke, no fill. */
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = NUM.THREE;               // three rotations
   const samples = NUM.ONEFORTYFOUR;
   const scale = Math.min(w, h) / NUM.THIRTYTHREE;
+  const cx = w / 2;
+  const cy = h / 2;
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const center = { x: w / 2, y: h / 2 };
-  const maxR = Math.min(w, h) / 2;
-  const tMax = NUM.ONEFORTYFOUR / NUM.TWENTYTWO;
-  const base = maxR / Math.pow(phi, tMax);
   ctx.beginPath();
-  for (let i = 0; i <= NUM.ONEFORTYFOUR; i++) {
-    const t = i / NUM.TWENTYTWO;
-    const r = base * Math.pow(phi, t);
-    const ang = t * 2 * Math.PI;
-    const x = center.x + r * Math.cos(ang);
-    const y = center.y + r * Math.sin(ang);
   for (let i = 0; i <= samples; i++) {
-    const t = (i / samples) * (Math.PI * 2 * turns);
-    const r = scale * Math.pow(phi, t / (Math.PI / 2));
-    const x = w / 2 + r * Math.cos(t);
-    const y = h / 2 + r * Math.sin(t);
-  // Static logarithmic spiral with 144 samples (12^2)
-  const cx = w / 2, cy = h / 2;
-  const phi = (1 + Math.sqrt(5)) / 2;         // golden ratio (approx)
-  const scale = Math.min(w, h) / NUM.THREE;   // fit to canvas using triad
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  for (let i = 0; i < NUM.ONEFORTYFOUR; i++) {
-    const t = (i / NUM.ONEFORTYFOUR) * NUM.TWENTYTWO * Math.PI / NUM.SEVEN; // gentle sweep
-    const r = scale * Math.pow(phi, t / (Math.PI * 2));
-    const x = cx + r * Math.cos(t);
-    const y = cy + r * Math.sin(t);
+    const theta = i * (Math.PI / NUM.ELEVEN);
+    const r = scale * Math.pow(phi, theta / Math.PI);
+    const x = cx + Math.cos(theta) * r;
+    const y = cy - Math.sin(theta) * r;
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
-  points.forEach(([x, y], idx) => {
-    if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  });
   ctx.stroke();
   ctx.restore();
 }
 
-/* Layer 4: Double-helix lattice */
+/* Layer 4: Double-helix lattice — two static strands with rungs */
 function drawHelix(ctx, w, h, colors, NUM) {
-  // ND-safe: static strands with 33 rungs
-  /* Double helix: two static sine strands with 33 rungs.
-     ND-safe: even spacing, no motion. */
-// Layer 4 ---------------------------------------------------------------
-function drawHelix(ctx, w, h, strandColor, rungColor, NUM) {
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: fixed lines, no flashing. */
-  // ND-safe: static lattice of two strands with cross rungs
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
+  const amp = h / NUM.NINE;       // gentle amplitude
+  const waves = NUM.ELEVEN;       // helix turns
+  const steps = NUM.NINETYNINE;   // sampling
   ctx.save();
   ctx.lineWidth = 2;
-  ctx.strokeStyle = strandColor;
 
   // strand A
   ctx.strokeStyle = colors.a;
-  ctx.save();
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
-
-/* Layer 4: Double-helix lattice (R004) */
-function drawHelix(ctx, w, h, colors, NUM) {
-  const amp = h / NUM.NINE;        // gentle amplitude
-  const waves = NUM.ELEVEN;        // helix turns
-  const steps = NUM.NINETYNINE;    // sampling
-  ctx.save();
-
-  // strand A
-  ctx.strokeStyle = colors.a;
-  ctx.lineWidth = 2;
-  ctx.strokeStyle = colors.a;
-
-  // strand A
-  ctx.strokeStyle = colors.a;
-/* Layer 4: Double-helix lattice ------------------------------------------- */
-function drawHelix(ctx, w, h, colors, NUM) {
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: even spacing, no motion. */
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
-  ctx.save();
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: no motion, even spacing. */
-  const amp = h / NUM.NINE;       // vertical amplitude
-  const waves = NUM.ELEVEN;       // number of waves across canvas
-  const steps = NUM.NINETYNINE;   // sampling for smoothness
-  ctx.save();
-
-  // strand A
-  ctx.strokeStyle = colors.a;
-  ctx.lineWidth = 2;
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const t = i / steps;
     const x = t * w;
     const y = h / 2 + Math.sin(t * waves * 2 * Math.PI) * amp;
-    const y = h/2 + Math.sin(t * waves * 2*Math.PI) * amp;
-    const y = h/2 + Math.sin(t * waves * 2 * Math.PI) * amp;
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
 
   // strand B (phase shift π)
-  // strand B phase shifted
-  ctx.strokeStyle = colors.b;
-  // strand B
-  // strand B (phase shifted)
-  // strand B (phase shifted by pi)
-  // strand B (phase π)
-  // strand B (phase shifted)
   ctx.strokeStyle = colors.b;
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const t = i / steps;
     const x = t * w;
     const y = h / 2 + Math.sin(t * waves * 2 * Math.PI + Math.PI) * amp;
-    const y = h/2 + Math.sin(t * waves * 2 * Math.PI + Math.PI) * amp;
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
 
-  // rungs
-  // cross rungs
-  ctx.strokeStyle = colors.rung;
-  // rungs
-  ctx.strokeStyle = rungColor;
-  // rungs
   // rungs
   ctx.strokeStyle = colors.rung;
   ctx.lineWidth = 1;
@@ -651,16 +143,6 @@ function drawHelix(ctx, w, h, colors, NUM) {
     const phase = t * waves * 2 * Math.PI;
     const y1 = h / 2 + Math.sin(phase) * amp;
     const y2 = h / 2 + Math.sin(phase + Math.PI) * amp;
-    const phase = t * waves * 2*Math.PI;
-    const y1 = h/2 + Math.sin(phase) * amp;
-    const y2 = h/2 + Math.sin(phase + Math.PI) * amp;
-    const y1 = h/2 + Math.sin(t * waves * 2 * Math.PI) * amp;
-    const y2 = h/2 + Math.sin(t * waves * 2 * Math.PI + Math.PI) * amp;
-    const y1 = h/2 + Math.sin(phase) * amp;
-    const y2 = h/2 + Math.sin(phase + Math.PI) * amp;
-    const phase = t * waves * 2*Math.PI;
-    const y1 = h/2 + Math.sin(phase) * amp;
-    const y2 = h/2 + Math.sin(phase + Math.PI) * amp;
     ctx.beginPath();
     ctx.moveTo(x, y1);
     ctx.lineTo(x, y2);


### PR DESCRIPTION
## Summary
- add offline ND-safe helix renderer
- wire vesica, tree-of-life, fibonacci, and helix layers
- document palette usage and numerology constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c508f59a6c8328bc50fe3a6f469f1e