### PR TITLE
Create ND-safe static cosmogenesis renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -5,24 +5,19 @@ Per Texturas Numerorum, Spira Loquitur.
 Static, offline canvas demo for layered sacred geometry. No build step, no network calls, ND-safe by design.
 
 ## Layers
-1. **Vesica field** — intersecting circles seed the grid (3, 7, 9)
-2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths
-3. **Fibonacci curve** — logarithmic spiral using 144 sampled points
-4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs
-1. **Vesica field** — intersecting circles seed the grid (3, 7, 9).
-2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths.
-3. **Fibonacci curve** — logarithmic spiral using 144 sampled points.
-4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs.
+1. **Vesica field** - intersecting circles seed the grid (3, 7, 9).
+2. **Tree-of-Life scaffold** - 10 nodes with 22 connective paths.
+3. **Fibonacci curve** - logarithmic spiral using 144 sampled points.
+4. **Double-helix lattice** - two phase-shifted strands with 33 cross rungs.
 
 ## Usage
-- Open `index.html` directly in any modern browser.
-- Optional: edit `data/palette.json` to change colors; if missing, a calm fallback palette is used and the header shows a notice.
+- Open `index.html` directly in any modern browser (double-click works offline).
+- Optional: edit `data/palette.json` to adjust colors; if the file is missing or unreadable, the renderer shows a header notice and falls back to the safe palette.
 
 ## ND-safe choices
 - No animation, autoplay, or flashing.
-- Gentle contrast with readable inks on dark background.
+- Gentle contrast with readable inks on a dark background.
 - Layer order preserves depth without motion.
 
 ## Numerology constants
-Constants exposed in `index.html` as `NUM` feed the geometry: 3, 7, 9, 11, 22, 33, 99, 144.
-The renderer uses constants that echo Fibonacci and Tarot harmonics: 3, 7, 9, 11, 22, 33, 99, 144.
+The renderer exposes constants that echo Fibonacci and Tarot harmonics: 3, 7, 9, 11, 22, 33, 99, 144. Geometry helpers rely on these values for spacing, sampling, and lattice rhythm.

--- a/data/palette.json
+++ b/data/palette.json
@@ -2,9 +2,6 @@
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
   "layers": [
-  "bg":"#0b0b12",
-  "ink":"#e8e8f0",
-  "layers":[
     "#b1c7ff",
     "#89f7fe",
     "#a0ffa1",
@@ -12,7 +9,4 @@
     "#f5a3ff",
     "#d0d0e6"
   ]
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 }

--- a/index.html
+++ b/index.html
@@ -7,25 +7,51 @@
   <meta name="color-scheme" content="light dark">
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+    :root {
+      --bg: #0b0b12;
+      --ink: #e8e8f0;
+      --muted: #a6a6c1;
+    }
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 14px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    }
+    header {
+      padding: 12px 16px;
+      border-bottom: 1px solid #1d1d2a;
+    }
+    .status {
+      color: var(--muted);
+      font-size: 12px;
+    }
+    #stage {
+      display: block;
+      margin: 16px auto;
+      box-shadow: 0 0 0 1px #1d1d2a;
+    }
+    .note {
+      max-width: 900px;
+      margin: 0 auto 16px;
+      color: var(--muted);
+    }
+    code {
+      background: #11111a;
+      padding: 2px 4px;
+      border-radius: 3px;
+    }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
-    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
@@ -46,21 +72,30 @@
 
     const defaults = {
       palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
       }
     };
 
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing or unreadable; using safe fallback.";
 
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    // Numerology constants drive geometry proportions for calm predictability.
+    const NUM = {
+      THREE: 3,
+      SEVEN: 7,
+      NINE: 9,
+      ELEVEN: 11,
+      TWENTYTWO: 22,
+      THIRTYTHREE: 33,
+      NINETYNINE: 99,
+      ONEFORTYFOUR: 144
+    };
 
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    // ND-safe rationale: no motion, high readability, intentional layer order.
+    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -2,171 +2,103 @@
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-  Layers drawn in order:
-    1) Vesica field — intersecting circles forming a calm grid
-    2) Tree-of-Life scaffold — 10 sephirot nodes + 22 paths
-    3) Fibonacci curve — logarithmic spiral using 144 samples
-    4) Double-helix lattice — two phase-shifted strands with 33 cross rungs
+  Layers rendered in depth order:
+    1) Vesica field - intersecting circles forming a calm grid
+    2) Tree-of-Life scaffold - 10 sephirot nodes with 22 connective paths
+    3) Fibonacci curve - logarithmic spiral sampled at 144 points
+    4) Double-helix lattice - two phase-shifted strands with 33 cross rungs
 
-  All functions are pure and run once; no motion, no dependencies.
-  Layers (drawn in order):
-    1) Vesica field — intersecting circles forming a calm grid
-    2) Tree-of-Life scaffold — 10 sephirot nodes + 22 paths
-    3) Fibonacci curve — logarithmic spiral polyline
-    4) Double-helix lattice — two phase-shifted strands with 33 rungs
-
-  All functions are pure and run once; no motion, no dependencies.
-  Layers  Layers (rendered in order):
-    1) Vesica field — intersecting circles
-    2) Tree-of-Life scaffold — 10 nodes with 22 paths
-    3) Fibonacci curve — logarithmic spiral polyline
-    4) Double-helix lattice — two phase-shifted strands with rungs
- are pure and run once; no motion, no dependencies.
->>>>>>> main
-  Layers (rendered in order):
-    1) Vesica field — intersecting circles
-    2) Tree-of-Life scaffold — 10 nodes with 22 paths
-    3) Fibonacci curve — logarithmic spiral polyline
-    4) Double-helix lattice — two phase-shifted strands with rungs
-
-  All functions are pure and run once; no motion, no dependencies.
-  Layers (rendered in order):
-    1) Vesica field — intersecting circles
-    2) Tree-of-Life scaffold — 10 nodes with 22 paths
-    3) Fibonacci curve — logarithmic spiral polyline
-    4) Double-helix lattice — two phase-shifted strands with rungs
-
-  All functions are pure and run once; no motion, no dependencies.
+  Each helper is a small pure function invoked once; no motion, no dependencies.
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
+  if (!ctx) {
+    return;
+  }
+
+  const layers = ensureLayers(palette.layers, palette.ink);
+
   ctx.save();
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  // Layer order preserves depth without motion
-  // layer order preserves depth without motion
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, {
-    a: palette.layers[4],
-    b: palette.layers[5],
-    rung: palette.ink
-  }, NUM);
-  /  // Layer order preserves depth without motion
-origin/codex/update-version-to-1.0.1-0d7tvt
->>>>>>> main
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, { a: palette.layers[4], b: palette.layers[5], rung: palette.ink }, NUM);
->>>>>>> main
+  // Layer order preserves visual depth without animation.
+  drawVesica(ctx, width, height, layers[0], NUM);
+  drawTree(ctx, width, height, layers[1], layers[2], NUM);
+  drawFibonacci(ctx, width, height, layers[3], NUM);
+  drawHelix(ctx, width, height, { a: layers[4], b: layers[5], rung: palette.ink }, NUM);
 
   ctx.restore();
 }
 
-<<<<<<< main
+function ensureLayers(layerList = [], fallback) {
+  const required = 6;
+  const resolved = [];
+  for (let i = 0; i < required; i++) {
+    resolved[i] = layerList[i] || fallback;
+  }
+  return resolved;
+}
+
 /* Layer 1: Vesica field ---------------------------------------------------- */
-/* Layer 1: Vesica field */
 function drawVesica(ctx, w, h, color, NUM) {
-  // ND-safe: thin lines, generous spacing
-  const r = Math.min(w, h) / NUM.THREE;      // triadic radius
-  const step = r / NUM.SEVEN;                // septenary spacing
-/* /* Layer 1: Vesica field ---------------------------------------------------- */
-function drawVesica(ctx, w, h, color, NUM) {
-  /* Vesica field: calm outline grid built from overlapping circles.
-     ND-safe: thin lines, generous spacing. */
-  const r = Math.min(w, h) / NUM.THREE;      // base radius from sacred triad
-  const step = r / NUM.SEVEN;                // spacing guided by 7
+  // ND-safe: thin strokes, gentle overlap grid referencing triadic and septenary steps.
+  const radius = Math.min(w, h) / NUM.THREE;
+  const offset = radius / NUM.SEVEN;
+  const stride = offset * NUM.NINE;
 
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 1;
+  ctx.globalAlpha = 0.45;
 
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-<<<<<<< main
-/* Layer 1: Vesica field — calm grid of intersecting circles */
-function drawVesica(ctx, w, h, color, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // triadic radius
-  const step = r / NUM.SEVEN;           // septenary spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-/* Layer 1: Vesica field — calm grid of intersecting circles */
-function drawVesica(ctx, w, h, color, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // triadic radius
-  const step = r / NUM.SEVEN;           // septenary spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
-      ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
+  for (let y = radius; y <= h + radius; y += stride) {
+    for (let x = radius; x <= w + radius; x += stride) {
+      drawCircle(ctx, x - offset, y, radius);
+      drawCircle(ctx, x + offset, y, radius);
     }
   }
+
   ctx.restore();
 }
 
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------ */
- 1: Vesi/* Layer 1: Vesica field — calm grid of intersecting circles */
-function drawVesica(ctx, w, h, color, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // triadic radius
-  const step = r / NUM.SEVEN;           // septenary spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
->>>>>>> main
-      ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
-      ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
->>>>>>>+origin/codex/up
-store();
+function drawCircle(ctx, cx, cy, r) {
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx.stroke();
 }
 
-/* Layer 2: Tree-of-Life scaffold */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  // Simplified sephirot layout: 3 columns, 5 rows
-  const xs = [w / 4, w / 2, (3 * w) / 4];
-  const ys = [h / 12, h / 3, h / 2, (2 * h) / 3, (11 * h) / 12];
+/* Layer 2: Tree-of-Life scaffold ------------------------------------------- */
+function drawTree(ctx, w, h, edgeColor, nodeColor, NUM) {
+  /* Tree-of-Life: static 10 node scaffold with 22 connective paths.
+     ND-safe: soft strokes, filled nodes for focus anchors. */
   const nodes = [
-    [xs[1], ys[0]], // crown
-    [xs[0], ys[1]], // wisdom
-    [xs[2], ys[1]], // understanding
-    [xs[0], ys[2]], // mercy
-    [xs[2], ys[2]], // severity
-    [xs[1], ys[2]], // beauty
-    [xs[0], ys[3]], // victory
-    [xs[2], ys[3]], // splendor
-    [xs[1], ys[3]], // foundation
-    [xs[1], ys[4]]  // kingdom
-  ];
+    [0.5, 0.08],
+    [0.35, 0.2],
+    [0.65, 0.2],
+    [0.25, 0.38],
+    [0.75, 0.38],
+    [0.5, 0.46],
+    [0.32, 0.64],
+    [0.68, 0.64],
+    [0.5, 0.72],
+    [0.5, 0.9]
+  ].map(([nx, ny]) => [nx * w, ny * h]);
 
-  const paths = [
-    [0,1],[0,2],[1,2],
-    [1,3],[1,5],[2,4],[2,5],
-    [3,4],[3,5],[4,5],
-    [3,6],[4,7],[5,6],[5,7],[6,7],
-    [6,8],[7,8],[8,9],
-    [3,8],[4,8],[1,4],[2,3]
-  ]; // 22 paths
+  const edges = [
+    [0, 1], [0, 2], [1, 2],
+    [1, 3], [1, 5], [2, 4], [2, 5],
+    [3, 4], [3, 5], [4, 5],
+    [3, 6], [5, 6], [4, 7], [5, 7], [6, 7],
+    [6, 8], [7, 8], [8, 9],
+    [3, 8], [4, 8], [1, 4], [2, 3]
+  ]; // 22 paths honoring tarot majors.
 
   ctx.save();
-  ctx.lineWidth = 1;
-  ctx.strokeStyle = pathColor;
-  paths.forEach(([a, b]) => {
+  ctx.strokeStyle = edgeColor;
+  ctx.lineWidth = 1.5;
+  ctx.globalAlpha = 0.6;
+  edges.forEach(([a, b]) => {
     const [x1, y1] = nodes[a];
     const [x2, y2] = nodes[b];
     ctx.beginPath();
@@ -176,285 +108,100 @@ function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
   });
 
   ctx.fillStyle = nodeColor;
+  ctx.globalAlpha = 0.85;
+  const radius = Math.min(w, h) / (NUM.TWENTYTWO * 2);
   nodes.forEach(([x, y]) => {
     ctx.beginPath();
-    ctx.arc(x, y, w / NUM.THIRTYTHREE, 0, Math.PI * 2);
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
     ctx.fill();
   });
-<<<<<<< main
-/* La/* Layer 2: Tree-of-Life scaffold ------------------------------------------ */
->>>>>>> main
-function drawTree(ctx, w, h, edgeColor, nodeColor, NUM) {
-  /* Tree-of-Life: ten nodes and twenty-two paths.
-     ND-safe: static layout with soft strokes and filled nodes. */
-  const nodes = [
-    [0.5, 0.1], [0.7, 0.2], [0.3, 0.2],
-    [0.75, 0.5], [0.25, 0.5], [0.5, 0.55],
-    [0.8, 0.8], [0.2, 0.8], [0.5, 0.85], [0.5, 0.95]
-  ];
 
-  const edges = [
-    [0,1],[0,2],[1,2],
-    [1,3],[2,4],[3,4],
-    [3,5],[4,5],[3,6],[4,7],[5,6],[5,7],[6,7],
-    [6,8],[7,8],[8,9],
-    [0,5],[1,5],[2,5],
-    [3,8],[4,8],[1,4],[2,3]
-  ];
-
-/* Layer 2: Tree-of-Life scaffold — 10 nodes, 22 paths */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  const nodes = [
-    [0.5, 0.05],
-    [0.25, 0.15], [0.75, 0.15],
-    [0.25, 0.3], [0.5, 0.35], [0.75, 0.3],
-    [0.25, 0.5], [0.75, 0.5],
-    [0.5, 0.6],
-    [0.5, 0.8]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const paths = [
-    [0,1],[0,2],
-    [1,2],[1,3],[1,4],[2,4],[2,5],
-    [3,4],[4,5],
-    [3,6],[4,6],[4,7],[5,7],
-    [6,8],[7,8],
-    [6,9],[7,9],
-    [8,9],
-    [3,5],[1,5],[2,3],[6,7]
-  ];
-
-/* Layer 2: Tree-of-Life scaffold — 10 nodes, 22 paths */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  const nodes = [
-    [0.5, 0.05],
-    [0.25, 0.15], [0.75, 0.15],
-    [0.25, 0.3], [0.5, 0.35], [0.75, 0.3],
-    [0.25, 0.5], [0.75, 0.5],
-    [0.5, 0.6],
-    [0.5, 0.8]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const paths = [
-    [0,1],[0,2],
-    [1,2],[1,3],[1,4],[2,4],[2,5],
-    [3,4],[4,5],
-    [3,6],[4,6],[4,7],[5,7],
-    [6,8],[7,8],
-    [6,9],[7,9],
-    [8,9],
-    [3,5],[1,5],[2,3],[6,7]
-  ];
-
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = 1;
-
-  edges.forEach(([a, b]) => {
-    const [ax, ay] = nodes[a];
-    const [bx, by] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(ax * w, ay * h);
-    ctx.lineTo(bx * w, by * h);
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-  nodes.forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x * w, y * h, w / NUM.NINETYNINE * 2, 0, Math.PI * 2);
-    ctx.fill();
-  });
   ctx.restore();
 }
 
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
+/* Layer 3: Fibonacci curve -------------------------------------------------- */
 function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci curve: logarithmic spiral sampling 144 points.
-     ND-safe: static polyline, no highlight. */
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.TWENTYTWO;
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-
-
-  edges.forEach(([a, b]) => {
-    const [ax, ay] = nodes[a];
-    const [bx, by] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(ax * w, ay * h);
-    ctx.lineTo(bx * w, by * h);
-: Tree-o/* Layer 2: Tree-of-Life scaffold — 10 nodes, 22 paths */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  const nodes = [
-    [0.5, 0.05],
-    [0.25, 0.15], [0.75, 0.15],
-    [0.25, 0.3], [0.5, 0.35], [0.75, 0.3],
-    [0.25, 0.5], [0.75, 0.5],
-    [0.5, 0.6],
-    [0.5, 0.8]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const paths = [
-    [0,1],[0,2],
-    [1,2],[1,3],[1,4],[2,4],[2,5],
-    [3,4],[4,5],
-    [3,6],[4,6],[4,7],[5,7],
-    [6,8],[7,8],
-    [6,9],[7,9],
-    [8,9],
-    [3,5],[1,5],[2,3],[6,7]
-  ];
-
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  paths.forEach(([a,b]) => {
-    ctx.beginPath();
-    ctx.moveTo(nodes[a][0], nodes[a][1]);
-    ctx.lineTo(nodes[b][0], nodes[b][1]);
->>>>>>>+origin/codex/up
-});
-
-  ctx.fillStyle = nodeColor;
-  nodes  nodes.forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x * w, y * h, w / NUM.NINETYNINE * 2, 0, Math.PI * 2);
->>>>>>>+main
-Math.min  const r = Math.min(w, h) / NUM.TWENTYTWO;
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
->>>>>>>+origin/codex/up
-;
->>>>>>> main
-  ctx.restore();
-}
-
-<<<<<<< main
-/* Laye/* Layer 3: Fibonacci curve ------------------------------------------------- */
-function drawFibonacci(ctx, w, h, color, NUM) {
-<<<<<<< codex/establish-full-stack-web-covenant
-  const samples = NUM.ONEFORTYFOUR;          // 144 samples
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-
-  for (let i = 0; i <= samples; i++) {
-    const t = (i / samples) * NUM.ELEVEN;
-    const r = scale * Math.pow(phi, t / NUM.THREE);
-    const angle = t;
-    const x = w / 2 + r * Math.cos(angle);
-    const y = h / 2 + r * Math.sin(angle);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-
-  ctx.stroke();
-  ctx.restore();
-  /* Fibonacci curve: logarithmic spiral sampling 144 points.
-     ND-safe: static polyline, no highlight. */
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.TWENTYTWO;
-
-Fibonacc/* Layer 3: Fibonacci curve — static logarithmic spiral */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const samples = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
+  // ND-safe: static spiral with consistent stroke weight and no motion.
   const cx = w / 2;
   const cy = h / 2;
->>>>>>>+origin/codex/up
-rokeStyle = color;
+  const base = Math.min(w, h) / NUM.NINETYNINE;
+  const phi = (1 + Math.sqrt(5)) / 2;
+
+  ctx.save();
+  ctx.strokeStyle = color;
   ctx.lineWidth = 2;
+  ctx.globalAlpha = 0.75;
   ctx.beginPath();
 
-  for (l
->>>>>>> main
-  for (let i = 0; i <= steps; i++) {
-    const theta = i * (Math.PI / NUM.ELEVEN);
-    const r = scale * Math.pow(phi, theta / (Math.PI * 2));
-    const x = w / 2 + r * Math.cos(theta);
-    const y = h / 2 + r * Math.sin(theta);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  for (let i = 0; i <= NUM.ONEFORTYFOUR; i++) {
+    const angle = (i / NUM.ELEVEN) * Math.PI;
+    const radius = base * Math.pow(phi, i / NUM.TWENTYTWO);
+    const x = cx + Math.cos(angle) * radius;
+    const y = cy + Math.sin(angle) * radius;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
 
-<<<<<<< codex/define-art-standards-in-codex-144-99-yj95r6
   ctx.stroke();
   ctx.restore();
 }
 
- 0; i <=  for (let i = 0; i <= samples; i++) {
-    const theta = i * (Math.PI / NUM.ELEVEN);
-    const r = scale * Math.pow(phi, theta / Math.PI);
-    const x = cx + Math.cos(theta) * r;
-    const y = cy - Math.sin(theta) * r;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
->>>>>>>+origin/codex/up
-restore();
->>>>>>> main
-}
-
->>>>>>> main
-/* Layer 4: Double-helix lattice ------------------------------------------- */
+/* Layer 4: Double-helix lattice -------------------------------------------- */
 function drawHelix(ctx, w, h, colors, NUM) {
-<<<<<<< codex/establish-full-stack-web-covenant
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: even spacing, no motion. */
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
+  /* Double helix: two static strands with 33 rungs.
+     ND-safe: no motion; amplitude trimmed for calm breathing space. */
+  const cycles = NUM.NINE; // nine rhythm waves across width
+  const freq = (Math.PI * 2 * cycles) / w;
+  const amplitude = h / NUM.THREE;
+  const offsetY = h / 2;
+  const phase = Math.PI / NUM.ELEVEN;
+  const strandCount = NUM.ONEFORTYFOUR;
+  const stepX = w / strandCount;
 
-<<<<<<< codex/define-art-standards-in-codex-144-99-yj95r6
-/* Layer 4: Double-helix lattice — two static strands with rungs */
-function drawHelix(ctx, w, h, colors, NUM) {
-  const amp = h / NUM.NINE;       // gentle amplitude
-  const waves = NUM.ELEVEN;       // helix turns
-  const steps = NUM.NINETYNINE;   // sampling
   ctx.save();
   ctx.lineWidth = 2;
 
-  // strand A
+  // Strand A
   ctx.strokeStyle = colors.a;
+  ctx.globalAlpha = 0.8;
   ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  for (let i = 0; i <= strandCount; i++) {
+    const x = i * stepX;
+    const y = helixY(x, freq, amplitude, offsetY, 0, 1);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
 
-  // strand B (phase shift π)
+  // Strand B with slight amplitude trim for layered depth
   ctx.strokeStyle = colors.b;
+  ctx.globalAlpha = 0.8;
   ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI + Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  for (let i = 0; i <= strandCount; i++) {
+    const x = i * stepX;
+    const y = helixY(x, freq, amplitude, offsetY, phase, 0.85);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
 
-  // cross rungs
-  // rungs
+  // Cross rungs unify strands at 33 points.
   ctx.strokeStyle = colors.rung;
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
-    const t = i / NUM.THIRTYTHREE;
-    const x = t * w;
-    const phase = t * waves * 2 * Math.PI;
-    const y1 = h / 2 + Math.sin(phase) * amp;
-    const y2 = h / 2 + Math.sin(phase + Math.PI) * amp;
+  ctx.globalAlpha = 0.35;
+  const rungCount = NUM.THIRTYTHREE;
+  for (let i = 0; i <= rungCount; i++) {
+    const x = (i / rungCount) * w;
+    const y1 = helixY(x, freq, amplitude, offsetY, 0, 1);
+    const y2 = helixY(x, freq, amplitude, offsetY, phase, 0.85);
     ctx.beginPath();
     ctx.moveTo(x, y1);
     ctx.lineTo(x, y2);
@@ -463,283 +210,7 @@ function drawHelix(ctx, w, h, colors, NUM) {
 
   ctx.restore();
 }
-/* La/* Layer 2: Tree-of-Life scaffold ------------------------------------------ */
->>>>>>> main
-function drawTree(ctx, w, h, edgeColor, nodeColor, NUM) {
-  /* Tree-of-Life: ten nodes and twenty-two paths.
-     ND-safe: static layout with soft strokes and filled nodes. */
-  const nodes = [
-    [0.5, 0.1], [0.7, 0.2], [0.3, 0.2],
-    [0.75, 0.5], [0.25, 0.5], [0.5, 0.55],
-    [0.8, 0.8], [0.2, 0.8], [0.5, 0.85], [0.5, 0.95]
-  ];
 
-  const edges = [
-    [0,1],[0,2],[1,2],
-    [1,3],[2,4],[3,4],
-    [3,5],[4,5],[3,6],[4,7],[5,6],[5,7],[6,7],
-    [6,8],[7,8],[8,9],
-    [0,5],[1,5],[2,5],
-    [3,8],[4,8],[1,4],[2,3]
-  ];
-
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = 1;
-<<<<<<< codex/define-art-standards-in-codex-144-99-yj95r6
-
-  edges.forEach(([a, b]) => {
-    const [ax, ay] = nodes[a];
-    const [bx, by] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(ax * w, ay * h);
-    ctx.lineTo(bx * w, by * h);
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-  nodes.forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x * w, y * h, w / NUM.NINETYNINE * 2, 0, Math.PI * 2);
-    ctx.fill();
-  });
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci curve: logarithmic spiral sampling 144 points.
-     ND-safe: static polyline, no highlight. */
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.TWENTYTWO;
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-
-
-  edges.forEach(([a, b]) => {
-    const [ax, ay] = nodes[a];
-    const [bx, by] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(ax * w, ay * h);
-    ctx.lineTo(bx * w, by * h);
-: Tree-o/* Layer 2: Tree-of-Life scaffold — 10 nodes, 22 paths */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  const nodes = [
-    [0.5, 0.05],
-    [0.25, 0.15], [0.75, 0.15],
-    [0.25, 0.3], [0.5, 0.35], [0.75, 0.3],
-    [0.25, 0.5], [0.75, 0.5],
-    [0.5, 0.6],
-    [0.5, 0.8]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const paths = [
-    [0,1],[0,2],
-    [1,2],[1,3],[1,4],[2,4],[2,5],
-    [3,4],[4,5],
-    [3,6],[4,6],[4,7],[5,7],
-    [6,8],[7,8],
-    [6,9],[7,9],
-    [8,9],
-    [3,5],[1,5],[2,3],[6,7]
-  ];
-
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  paths.forEach(([a,b]) => {
-    ctx.beginPath();
-    ctx.moveTo(nodes[a][0], nodes[a][1]);
-    ctx.lineTo(nodes[b][0], nodes[b][1]);
->>>>>>>+origin/codex/up
-});
-
-  ctx.fillStyle = nodeColor;
-  nodes  nodes.forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x * w, y * h, w / NUM.NINETYNINE * 2, 0, Math.PI * 2);
->>>>>>>+main
-Math.min  const r = Math.min(w, h) / NUM.TWENTYTWO;
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
->>>>>>>+origin/codex/up
-;
->>>>>>> main
-  ctx.restore();
-}
-
-<<<<<<< main
-/* Laye/* Layer 3: Fibonacci curve ------------------------------------------------- */
-function drawFibonacci(ctx, w, h, color, NUM) {
-<<<<<<< codex/establish-full-stack-web-covenant
-  const samples = NUM.ONEFORTYFOUR;          // 144 samples
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-
-  for (let i = 0; i <= samples; i++) {
-    const t = (i / samples) * NUM.ELEVEN;
-    const r = scale * Math.pow(phi, t / NUM.THREE);
-    const angle = t;
-    const x = w / 2 + r * Math.cos(angle);
-    const y = h / 2 + r * Math.sin(angle);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-
-  ctx.stroke();
-  ctx.restore();
-  /* Fibonacci curve: logarithmic spiral sampling 144 points.
-     ND-safe: static polyline, no highlight. */
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.TWENTYTWO;
-
-Fibonacc/* Layer 3: Fibonacci curve — static logarithmic spiral */
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-  const r = Math.min(w, h) / NUM.TWENTYTWO;
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.fill();
-  });
-  ctx.restore();
-}
-
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-  const r = Math.min(w, h) / NUM.TWENTYTWO;
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.fill();
-  });
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve — static logarithmic spiral */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const samples = NUM.ONEFORTYFOUR;
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE;
-  const cx = w / 2;
-  const cy = h / 2;
->>>>>>>+origin/codex/up
-rokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-
-  for (l
->>>>>>> main
-  for (let i = 0; i <= steps; i++) {
-    const theta = i * (Math.PI / NUM.ELEVEN);
-    const r = scale * Math.pow(phi, theta / (Math.PI * 2));
-    const x = w / 2 + r * Math.cos(theta);
-    const y = h / 2 + r * Math.sin(theta);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-
-<<<<<<< codex/define-art-standards-in-codex-144-99-yj95r6
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  for (let i = 0; i <= samples; i++) {
-    const theta = i * (Math.PI / NUM.ELEVEN);
-    const r = scale * Math.pow(phi, theta / Math.PI);
-    const x = cx + Math.cos(theta) * r;
-    const y = cy - Math.sin(theta) * r;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-  ctx.restore();
-}
-
- 0; i <=  for (let i = 0; i <= samples; i++) {
-    const theta = i * (Math.PI / NUM.ELEVEN);
-    const r = scale * Math.pow(phi, theta / Math.PI);
-    const x = cx + Math.cos(theta) * r;
-    const y = cy - Math.sin(theta) * r;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
->>>>>>>+origin/codex/up
-restore();
->>>>>>> main
-}
-
->>>>>>> main
-/* Layer 4: Double-helix lattice ------------------------------------------- */
-function drawHelix(ctx, w, h, colors, NUM) {
-<<<<<<< codex/establish-full-stack-web-covenant
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: even spacing, no motion. */
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
-
-<<<<<<< codex/define-art-standards-in-codex-144-99-yj95r6
-/* Layer 4: Double-helix lattice — two static strands with rungs */
-function drawHelix(ctx, w, h, colors, NUM) {
-  const amp = h / NUM.NINE;       // gentle amplitude
-  const waves = NUM.ELEVEN;       // helix turns
-  const steps = NUM.NINETYNINE;   // sampling
-  ctx.save();
-  ctx.lineWidth = 2;
-
-  // strand A
-  ctx.strokeStyle = colors.a;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  // strand B (phase shift π)
-  ctx.strokeStyle = colors.b;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI + Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  // cross rungs
-  // rungs
-  ctx.strokeStyle = colors.rung;
-  ctx.lineWidth = 1;
-  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
-    const t = i / NUM.THIRTYTHREE;
-    const x = t * w;
-    const phase = t * waves * 2 * Math.PI;
-    const y1 = h / 2 + Math.sin(phase) * amp;
-    const y2 = h / 2 + Math.sin(phase + Math.PI) * amp;
-    ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
-    ctx.stroke();
-  }
-
-  ctx.restore();
+function helixY(x, freq, amplitude, offsetY, phase, scale) {
+  return offsetY + Math.sin(freq * x + phase) * amplitude * scale;
 }


### PR DESCRIPTION
## Summary
- rebuild the offline index.html shell with calm styling, palette fallback messaging, and numerology constants
- implement a pure-function helix renderer that draws the vesica grid, tree-of-life scaffold, fibonacci spiral, and static double helix lattice
- clean up palette data and documentation to reflect ND-safe usage guidance and numerology parameters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8aec4f8c88328a0f2a4dd9ee4ae42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More resilient palette handling with automatic safe fallback and updated on-screen message.
  - Consistent six-layer rendering with graceful recovery from missing colors.
  - Refined visuals: calmer double-helix with cross-rungs, enhanced Tree-of-Life, deterministic Fibonacci spiral, vesica field updates, and added circle-grid pattern.

- Bug Fixes
  - Corrected malformed palette data to prevent load/render issues.
  - Safeguard against rendering when canvas context is unavailable.

- Documentation
  - Clarified Layers, Usage, ND-safe choices, and Numerology constants.
  - Added offline usage tips and palette file guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->