### PR TITLE
Clean ND-safe helix renderer files

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -2,13 +2,13 @@ Per Texturas Numerorum, Spira Loquitur.
 
 # Cosmic Helix Renderer
 
-Static, offline canvas demo for layered sacred geometry. No build step, no network calls, ND-safe by design.
+Static, offline canvas renderer for layered sacred geometry. No build step, no network calls, ND-safe by design.
 
 ## Layers
-1. **Vesica field** — intersecting circles seed the grid (3, 7, 9)
-2. **Tree-of-Life scaffold** — 10 nodes with 22 connective paths
-3. **Fibonacci curve** — logarithmic spiral using 144 sampled points
-4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs
+1. **Vesica field** - intersecting circles seed the grid (3, 7, 9)
+2. **Tree-of-Life scaffold** - 10 nodes with 22 connective paths
+3. **Fibonacci curve** - logarithmic spiral using 144 sampled points
+4. **Double-helix lattice** - two phase-shifted strands with 33 cross rungs
 
 ## Usage
 - Open `index.html` directly in any modern browser.
@@ -20,5 +20,4 @@ Static, offline canvas demo for layered sacred geometry. No build step, no netwo
 - Layer order preserves depth without motion.
 
 ## Numerology constants
-The renderer uses constants that echo Fibonacci and Tarot harmonics: 3, 7, 9, 11, 22, 33, 99, 144.
-Constants exposed in `index.html` as `NUM` feed the geometry: 3, 7, 9, 11, 22, 33, 99, 144.
+The renderer references 3, 7, 9, 11, 22, 33, 99, and 144 to align with the cathedral numerology and geometry mappings.

--- a/data/palette.json
+++ b/data/palette.json
@@ -9,5 +9,4 @@
     "#f5a3ff",
     "#d0d0e6"
   ]
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 }

--- a/index.html
+++ b/index.html
@@ -7,25 +7,51 @@
   <meta name="color-scheme" content="light dark">
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system, Segoe UI, Roboto, sans-serif; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+    :root {
+      --bg: #0b0b12;
+      --ink: #e8e8f0;
+      --muted: #a6a6c1;
+    }
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 14px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    }
+    header {
+      padding: 12px 16px;
+      border-bottom: 1px solid #1d1d2a;
+    }
+    .status {
+      color: var(--muted);
+      font-size: 12px;
+    }
+    #stage {
+      display: block;
+      margin: 16px auto;
+      box-shadow: 0 0 0 1px #1d1d2a;
+    }
+    .note {
+      max-width: 900px;
+      margin: 0 auto 16px;
+      color: var(--muted);
+    }
+    code {
+      background: #11111a;
+      padding: 2px 4px;
+      border-radius: 3px;
+    }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette...</div>
-    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
@@ -39,16 +65,16 @@
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
-      } catch {
+      } catch (error) {
         return null;
       }
     }
 
     const defaults = {
       palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
       }
     };
 
@@ -56,11 +82,20 @@
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    // Numerology constants used by the geometry routines
+    const NUM = {
+      THREE: 3,
+      SEVEN: 7,
+      NINE: 9,
+      ELEVEN: 11,
+      TWENTYTWO: 22,
+      THIRTYTHREE: 33,
+      NINETYNINE: 99,
+      ONEFORTYFOUR: 144
+    };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,15 +1,17 @@
-/*
-  helix-renderer.mjs
-  ND-safe static renderer for layered sacred geometry.
-
-  Layers:
-    1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot nodes + 22 paths)
-    3) Fibonacci curve (logarithmic spiral polyline)
-    4) Double-helix lattice (two phase-shifted strands)
-
-  All drawing routines are pure and run exactly once. No animation and no external dependencies.
-*/
+/**
+ * Render a static, non-animated multi-layer sacred-geometry composition onto a canvas.
+ *
+ * Clears the canvas to palette.bg then draws four layers in this fixed order:
+ * 1) Vesica field (intersecting circle outlines),
+ * 2) Tree-of-Life scaffold (10 nodes + 22 paths),
+ * 3) Fibonacci logarithmic spiral,
+ * 4) Double-helix lattice (two phase-shifted strands with cross rungs).
+ *
+ * The function is deterministic and side-effect-limited to drawing on the provided canvas context.
+ *
+ * @param {object} palette - Color palette used for rendering. Expected shape: { bg: string, layers: string[], ink: string } where `layers` supplies layer stroke colors in the order consumed by the renderer.
+ * @param {object} NUM - Numeric constants used for sizing and spacing (e.g., scaling and sample counts).
+ */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.save();
@@ -25,7 +27,21 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.restore();
 }
 
-/* Layer 1: Vesica field ---------------------------------------------------- */
+/**
+ * Draws a calm, non-animated field of overlapping vesica-style circle outlines.
+ *
+ * Renders a static grid of paired circles across the canvas using a thin stroke.
+ * Circle size and spacing are derived from the provided numeric constants to keep
+ * composition proportional to the canvas dimensions.
+ *
+ * @param {number} w - Canvas width in pixels.
+ * @param {number} h - Canvas height in pixels.
+ * @param {string|CanvasGradient|CanvasPattern} color - Stroke style used for the circle outlines.
+ * @param {Object} NUM - Scaling constants object. Expected numeric properties:
+ *   - THREE: divisor used to compute the base circle radius (Math.min(w,h) / THREE)
+ *   - SEVEN: divisor used to compute the finer step (baseRadius / SEVEN)
+ *   - NINE: multiplier used to space grid rows/columns (step * NINE)
+ */
 function drawVesica(ctx, w, h, color, NUM) {
   /* Vesica field: calm outlines from overlapping circles.
      ND-safe: thin strokes, ample spacing, static grid. */
@@ -51,7 +67,19 @@ function drawVesica(ctx, w, h, color, NUM) {
   ctx.restore();
 }
 
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------- */
+/**
+ * Render a static Tree-of-Life scaffold: 10 nodes connected by 22 paths.
+ *
+ * Draws a fixed, non-animated arrangement of nodes and connecting lines onto the provided canvas
+ * context. Coordinates are computed from a normalized layout scaled to the given width/height.
+ * The canvas state is saved and restored; drawing mutates only the provided context.
+ *
+ * @param {Object} colors - Color map used for rendering. Required properties:
+ *   - {string} node - fill color for each node.
+ *   - {string} path - stroke color for connecting paths.
+ * @param {Object} NUM - Numeric constants used for sizing. This function uses NUM.TWENTYTWO
+ *   to compute the node radius (nodeRadius = Math.min(w, h) / NUM.TWENTYTWO).
+ */
 function drawTree(ctx, w, h, colors, NUM) {
   /* Tree-of-Life: 10 nodes with 22 connective paths.
      ND-safe: static composition, balanced spacing, gentle line weights. */
@@ -107,7 +135,18 @@ function drawTree(ctx, w, h, colors, NUM) {
   ctx.restore();
 }
 
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
+/**
+ * Draws a static Fibonacci (logarithmic) spiral centered on the canvas.
+ *
+ * Renders a single stroked polyline approximating a logarithmic spiral sampled at 144 points
+ * (11 turns). The spiral is centered at (w/2, h/2) and scaled from Math.min(w, h).
+ * Non-animated — produces a single deterministic stroke.
+ *
+ * @param {object} NUM - Numeric constants used by the routine. Required fields:
+ *   ONEFORTYFOUR (number): sample count (144),
+ *   ELEVEN (number): number of half-π multiples used to produce ~11 turns,
+ *   THIRTYTHREE (number): divisor used to compute the spiral scale.
+ */
 function drawFibonacci(ctx, w, h, color, NUM) {
   /* Fibonacci spiral: static logarithmic spiral sampled at 144 points.
      ND-safe: single stroke, no motion or flashing. */
@@ -138,7 +177,23 @@ function drawFibonacci(ctx, w, h, color, NUM) {
   ctx.restore();
 }
 
-/* Layer 4: Double-helix lattice ------------------------------------------- */
+/**
+ * Draws a static double-helix lattice: two phase-shifted sine-wave strands with evenly spaced cross rungs.
+ *
+ * Renders two stroked polylines (strandA and strandB) that form an 11-turn helix across the canvas width and
+ * a set of vertical rungs connecting the strands at 33 evenly spaced positions. The helix is centered
+ * vertically and scaled by the provided NUM constants so the result is deterministic and non-animated.
+ *
+ * @param {CanvasRenderingContext2D} ctx - Canvas 2D rendering context to draw into.
+ * @param {number} w - Canvas width in pixels.
+ * @param {number} h - Canvas height in pixels.
+ * @param {{strandA: string, strandB: string, rung: string}} colors - Stroke colors for the two strands and the rungs.
+ * @param {{NINE: number, ELEVEN: number, NINETYNINE: number, THIRTYTHREE: number}} NUM - Numeric constants used for sizing:
+ *   - NINE: divisor used to compute vertical amplitude (amplitude = h / NINE).
+ *   - ELEVEN: number of helical turns across the width.
+ *   - NINETYNINE: number of sample steps per strand.
+ *   - THIRTYTHREE: number of cross-rungs (evenly spaced; 33 used).
+ */
 function drawHelix(ctx, w, h, colors, NUM) {
   /* Double-helix: paired sine waves with 33 static cross rungs.
      ND-safe: even spacing, no oscillation over time, readable contrast. */

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -4,19 +4,11 @@
 
   Layers:
     1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
-    3) Fibonacci curve (log spiral polyline)
+    2) Tree-of-Life scaffold (10 sephirot nodes + 22 paths)
+    3) Fibonacci curve (logarithmic spiral polyline)
     4) Double-helix lattice (two phase-shifted strands)
 
-  All functions are pure and run once; no motion, no dependencies.
-  Layers drawn in order:
-    1) Vesica field — intersecting circles forming a calm grid
-    2) Tree-of-Life scaffold — 10 sephirot nodes + 22 paths
-    3) Fibonacci curve — logarithmic spiral using 144 sampled points
-    4) Double-helix lattice — two phase-shifted strands with 33 cross rungs
-
-  All functions are pure and run once; no motion, no dependencies.
-  Functions are pure and run once; no motion, no dependencies.
+  All drawing routines are pure and run exactly once. No animation and no external dependencies.
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
@@ -24,203 +16,91 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  // Layer order preserves depth without motion
+  // Layer order preserves depth without motion (ND-safe rationale)
   drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawTree(ctx, width, height, { path: palette.layers[1], node: palette.layers[2] }, NUM);
   drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, {
-    a: palette.layers[4],
-    b: palette.layers[5],
-    rung: palette.ink
-  }, NUM);
-  drawHelix(ctx, width, height, { a: palette.layers[4], b: palette.layers[5], rung: palette.ink }, NUM);
+  drawHelix(ctx, width, height, { strandA: palette.layers[4], strandB: palette.layers[5], rung: palette.ink }, NUM);
 
   ctx.restore();
 }
 
-/* Layer 1: Vesica field — calm grid of intersecting circles */
 /* Layer 1: Vesica field ---------------------------------------------------- */
-/* Layer 1: Vesica field -- calm grid of intersecting circles */
 function drawVesica(ctx, w, h, color, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // triadic radius
-  const step = r / NUM.SEVEN;           // septenary spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-function drawVesica(ctx, w, h, color, NUM) {
-  /* Vesica field: calm outline grid built from overlapping circles.
-     ND-safe: thin lines, generous spacing. */
-  const r = Math.min(w, h) / NUM.THREE;      // base radius from sacred triad
-  const step = r / NUM.SEVEN;                // spacing guided by 7
-/* Layer 1: Vesica field — calm grid of intersecting circles */
-function drawVesica(ctx, w, h, color, NUM) {
-  // ND-safe: thin lines, generous spacing
-  const r = Math.min(w, h) / NUM.THREE;       // triadic radius
-  const step = r / NUM.SEVEN;                 // septenary spacing
+  /* Vesica field: calm outlines from overlapping circles.
+     ND-safe: thin strokes, ample spacing, static grid. */
+  const baseRadius = Math.min(w, h) / NUM.THREE; // sacred triad scaling
+  const step = baseRadius / NUM.SEVEN;           // septenary spacing controls density
 
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 1;
 
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
-      ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
+  for (let y = baseRadius; y < h; y += step * NUM.NINE) {
+    for (let x = baseRadius; x < w; x += step * NUM.NINE) {
+      ctx.beginPath();
+      ctx.arc(x - step, y, baseRadius, 0, Math.PI * 2);
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.arc(x + step, y, baseRadius, 0, Math.PI * 2);
+      ctx.stroke();
     }
   }
 
-/* Layer 2: Tree-of-Life scaffold — nodes and connective paths */
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  const nodes = [
-    [0.5, 0.1], [0.65, 0.2], [0.35, 0.2],
-    [0.7, 0.4], [0.3, 0.4], [0.5, 0.5],
-    [0.75, 0.7], [0.25, 0.7], [0.5, 0.8],
   ctx.restore();
 }
 
 /* Layer 2: Tree-of-Life scaffold ------------------------------------------- */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  /* Tree-of-Life: 10 sephirot nodes linked by 22 paths.
-     ND-safe: static layout, thin lines. */
-
-  const nodes = [
-    [0.5, 0.05], [0.75, 0.18], [0.25, 0.18],
-    [0.25, 0.38], [0.75, 0.38], [0.5, 0.52],
-    [0.25, 0.66], [0.75, 0.66], [0.5, 0.8], [0.5, 0.93]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const paths = [
-    [0,1],[0,2],[0,5],
-    [1,2],[1,5],[1,4],
-    [2,3],[2,5],[2,4],
-    [3,5],[3,6],
-    [4,5],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,7],[6,8],[6,9],
-    [7,8],[7,9],
-    [8,9]
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-    }
-  }
-
-  ctx.restore();
-}
-
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------ */
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
+function drawTree(ctx, w, h, colors, NUM) {
   /* Tree-of-Life: 10 nodes with 22 connective paths.
-     ND-safe: static layout, readable contrast. */
-  const nodes = [
-    [0.5, 0.05], [0.75, 0.15], [0.25, 0.15],
-    [0.75, 0.35], [0.25, 0.35], [0.5, 0.45],
-    [0.75, 0.65], [0.25, 0.65], [0.5, 0.75], [0.5, 0.90]
+     ND-safe: static composition, balanced spacing, gentle line weights. */
+  const normalizedNodes = [
+    [0.50, 0.05], // Keter
+    [0.65, 0.18], // Chokmah
+    [0.35, 0.18], // Binah
+    [0.70, 0.35], // Chesed
+    [0.30, 0.35], // Geburah
+    [0.50, 0.48], // Tiphereth
+    [0.70, 0.64], // Netzach
+    [0.30, 0.64], // Hod
+    [0.50, 0.78], // Yesod
+    [0.50, 0.92]  // Malkuth
   ];
-  const edges = [
-    [0,1],[0,2],
-    [1,3],[1,4],[1,5],
-    [2,3],[2,4],[2,5],
-    [3,5],[3,6],[3,7],
-    [4,5],[4,6],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,8],[6,9],
-    [7,8],[7,9],
-    [8,9]
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-    }
-  }
-  ctx.restore();
-}
 
-/* Layer 2: Tree-of-Life scaffold -- nodes and paths */
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  const pts = [
-    [0.5, 0.1],
-    [0.25, 0.2],
-    [0.75, 0.2],
-    [0.25, 0.4],
-    [0.75, 0.4],
-    [0.5, 0.5],
-    [0.25, 0.7],
-    [0.75, 0.7],
-    [0.5, 0.8],
-    [0.5, 0.9]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const edges = [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],
-    [3,6],[4,7],[6,7],[6,8],[7,8],[8,9],[5,6],[5,7],
-    [5,8],[2,5],[1,5],[2,3],[1,4],[0,5]
-    [0,1],[0,2],[1,2],[1,3],[1,5],[2,4],[2,5],[3,4],[3,5],[3,6],
-    [4,5],[4,7],[5,6],[5,7],[5,8],[6,8],[6,9],[7,8],[7,9],[8,9],
-    [1,7],[2,8]
-  ctx.restore();
-}
-
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------- */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  /* Tree-of-Life: 10 sephirot nodes linked by 22 paths.
-     ND-safe: static layout, thin lines. */
-
-  const nodes = [
-    [0.5, 0.05], [0.75, 0.18], [0.25, 0.18],
-    [0.25, 0.38], [0.75, 0.38], [0.5, 0.52],
-    [0.25, 0.66], [0.75, 0.66], [0.5, 0.8], [0.5, 0.93]
-  ].map(([x, y]) => [x * w, y * h]);
+  const nodes = normalizedNodes.map(([x, y]) => [x * w, y * h]);
 
   const paths = [
-    [0,1],[0,2],[0,5],
-    [1,2],[1,5],[1,4],
-    [2,3],[2,5],[2,4],
-    [3,5],[3,6],
-    [4,5],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,7],[6,8],[6,9],
-    [7,8],[7,9],
-    [8,9]
+    [0, 1], [0, 2], [0, 5],
+    [1, 2], [1, 3], [1, 5],
+    [2, 4], [2, 5],
+    [3, 5], [3, 6], [3, 8],
+    [4, 5], [4, 7], [4, 8],
+    [5, 6], [5, 7], [5, 8],
+    [6, 8], [6, 9],
+    [7, 8], [7, 9],
+    [8, 9]
   ];
 
   ctx.save();
-  ctx.strokeStyle = pathColor;
+  ctx.strokeStyle = colors.path;
   ctx.lineWidth = 1;
+
   paths.forEach(([a, b]) => {
     const [x1, y1] = nodes[a];
     const [x2, y2] = nodes[b];
     ctx.beginPath();
     ctx.moveTo(x1, y1);
     ctx.lineTo(x2, y2);
-
-  edges.forEach(([a,b]) => {
-    const ax = nodes[a][0] * w, ay = nodes[a][1] * h;
-    const bx = nodes[b][0] * w, by = nodes[b][1] * h;
-    ctx.beginPath();
-    ctx.moveTo(ax, ay);
-    ctx.lineTo(bx, by);
     ctx.stroke();
   });
 
-  ctx.fillStyle = nodeColor;
-  const r = Math.min(w, h) / NUM.TWENTYTWO;
+  ctx.fillStyle = colors.node;
+  const nodeRadius = Math.min(w, h) / NUM.TWENTYTWO; // ties to 22 paths
+
   nodes.forEach(([x, y]) => {
     ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.arc(x, y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
   });
 
@@ -229,99 +109,11 @@ function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
 
 /* Layer 3: Fibonacci curve ------------------------------------------------- */
 function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci spiral: static logarithmic curve.
-     ND-safe: single stroke, no motion. */
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x * w, y * h, r, 0, Math.PI * 2);
-    ctx.fill();
-  });
-
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
-  ctx.lineWidth = 1.5;
-  edges.forEach(([a, b]) => {
-    ctx.beginPath();
-  ctx.lineWidth = 1.5;
-  edges.forEach(([a, b]) => {
-    ctx.beginPath();
-    ctx.moveTo(pts[a][0], pts[a][1]);
-    ctx.lineTo(pts[b][0], pts[b][1]);
-  ctx.restore();
-}
-
-/* Layer 2: Tree-of-Life scaffold — nodes and paths */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  // Layout approximates the sefirot; static and evenly spaced
-  const cx = w / 2;
-  const top = h / NUM.NINE;
-  const bottom = h - top;
-  const middle = (top + bottom) / 2;
-  const quarter = (top + middle) / 2;
-  const threeQuarter = (middle + bottom) / 2;
-
-  const nodes = [
-    [cx, top],
-    [cx - w / NUM.SEVEN, quarter],
-    [cx + w / NUM.SEVEN, quarter],
-    [cx - w / NUM.NINE, middle],
-    [cx + w / NUM.NINE, middle],
-    [cx, middle + h / NUM.TWENTYTWO],
-    [cx - w / NUM.NINE, threeQuarter],
-    [cx + w / NUM.NINE, threeQuarter],
-    [cx, bottom - h / NUM.ELEVEN],
-    [cx, bottom]
-  ];
-
-  const paths = [
-    [0,1],[0,2],[1,3],[2,4],[3,4],[3,5],[4,5],[3,6],[4,7],[6,7],[6,8],[7,8],[5,8],[8,9]
-  ];
-
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  edges.forEach(([a, b]) => {
-    ctx.beginPath();
-    ctx.moveTo(nodes[a][0], nodes[a][1]);
-    ctx.lineTo(nodes[b][0], nodes[b][1]);
-
-  paths.forEach(([a,b]) => {
-    const [x1,y1] = nodes[a];
-    const [x2,y2] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(x1, y1);
-    ctx.lineTo(x2, y2);
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-  const r = Math.min(w, h) / NUM.TWENTYTWO;
-  nodes.forEach(([x, y]) => {
-  pts.forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.fill();
-  });
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve -- static logarithmic spiral */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Logarithmic spiral with fixed samples.
-     ND-safe: static polyline, no motion. */
-
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci spiral: static logarithmic curve.
-     ND-safe: single stroke, no motion. */
+  /* Fibonacci spiral: static logarithmic spiral sampled at 144 points.
+     ND-safe: single stroke, no motion or flashing. */
   const phi = (1 + Math.sqrt(5)) / 2;
-  const samples = NUM.ONEFORTYFOUR;               // 144 points
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE; // gentle size
+  const samples = NUM.ONEFORTYFOUR;           // 144 lattice points
+  const scale = Math.min(w, h) / NUM.THIRTYTHREE; // gentle amplitude referencing 33 spine
   const cx = w / 2;
   const cy = h / 2;
 
@@ -331,72 +123,72 @@ function drawFibonacci(ctx, w, h, color, NUM) {
   ctx.beginPath();
 
   for (let i = 0; i <= samples; i++) {
-    const theta = i * (Math.PI / NUM.ELEVEN);
-    const r = scale * Math.pow(phi, theta / Math.PI);
-    const x = w / 2 + Math.cos(theta) * r;
-    const y = h / 2 - Math.sin(theta) * r;
-    const r = scale * Math.pow(phi, theta / (Math.PI * 2));
-    const x = cx + Math.cos(theta) * r;
-    const y = cy + Math.sin(theta) * r;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    const theta = (i / samples) * NUM.ELEVEN * Math.PI; // 11 turns for balance
+    const radius = scale * Math.pow(phi, theta / (2 * Math.PI));
+    const x = cx + Math.cos(theta) * radius;
+    const y = cy - Math.sin(theta) * radius;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
 
   ctx.stroke();
   ctx.restore();
 }
 
-/* Layer 4: Double-helix lattice — two static strands with rungs */
 /* Layer 4: Double-helix lattice ------------------------------------------- */
 function drawHelix(ctx, w, h, colors, NUM) {
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: even spacing, no motion. */
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
-/* Layer 4: Double-helix lattice -- two static strands with rungs */
-function drawHelix(ctx, w, h, colors, NUM) {
-  const amp = h / NUM.NINE;       // gentle amplitude
-  const waves = NUM.ELEVEN;       // helix turns
-  const steps = NUM.NINETYNINE;   // sampling
-/* Layer 4: Double-helix lattice — two static strands with rungs */
-function drawHelix(ctx, w, h, colors, NUM) {
-  // ND-safe: even spacing, no motion
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
+  /* Double-helix: paired sine waves with 33 static cross rungs.
+     ND-safe: even spacing, no oscillation over time, readable contrast. */
+  const amplitude = h / NUM.NINE;              // ternary harmony softened by ninefold division
+  const waves = NUM.ELEVEN;                    // 11 helical turns across width
+  const steps = NUM.NINETYNINE;                // 99 samples along each strand
+  const centerY = h / 2;
 
   ctx.save();
   ctx.lineWidth = 2;
 
-  ctx.strokeStyle = colors.a;
+  // Strand A
+  ctx.strokeStyle = colors.strandA;
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const t = i / steps;
     const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    const y = centerY + Math.sin(t * waves * Math.PI * 2) * amplitude;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
 
-  ctx.strokeStyle = colors.b;
+  // Strand B (phase shifted by pi)
+  ctx.strokeStyle = colors.strandB;
   ctx.beginPath();
   for (let i = 0; i <= steps; i++) {
     const t = i / steps;
     const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI + Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    const y = centerY + Math.sin(t * waves * Math.PI * 2 + Math.PI) * amplitude;
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
 
-  // cross rungs
+  // Cross rungs referencing 33 spine
   ctx.strokeStyle = colors.rung;
   ctx.lineWidth = 1;
   for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
     const t = i / NUM.THIRTYTHREE;
     const x = t * w;
-    const phase = t * waves * 2 * Math.PI;
-    const y1 = h / 2 + Math.sin(phase) * amp;
-    const y2 = h / 2 + Math.sin(phase + Math.PI) * amp;
+    const phase = t * waves * Math.PI * 2;
+    const y1 = centerY + Math.sin(phase) * amplitude;
+    const y2 = centerY + Math.sin(phase + Math.PI) * amplitude;
     ctx.beginPath();
     ctx.moveTo(x, y1);
     ctx.lineTo(x, y2);

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -68,17 +68,18 @@ function drawVesica(ctx, w, h, color, NUM) {
 }
 
 /**
- * Render a static Tree-of-Life scaffold: 10 nodes connected by 22 paths.
+ * Draws a static Tree-of-Life scaffold: 10 filled nodes connected by 22 stroked paths.
  *
- * Draws a fixed, non-animated arrangement of nodes and connecting lines onto the provided canvas
- * context. Coordinates are computed from a normalized layout scaled to the given width/height.
- * The canvas state is saved and restored; drawing mutates only the provided context.
+ * Nodes are defined as normalized (0..1) positions and scaled to the given width/height.
+ * The canvas state is saved and restored; drawing only mutates the provided 2D context.
  *
- * @param {Object} colors - Color map used for rendering. Required properties:
+ * @param {number} w - Canvas width used to scale normalized node X coordinates.
+ * @param {number} h - Canvas height used to scale normalized node Y coordinates.
+ * @param {Object} colors - Color map for rendering. Required properties:
  *   - {string} node - fill color for each node.
  *   - {string} path - stroke color for connecting paths.
- * @param {Object} NUM - Numeric constants used for sizing. This function uses NUM.TWENTYTWO
- *   to compute the node radius (nodeRadius = Math.min(w, h) / NUM.TWENTYTWO).
+ * @param {Object} NUM - Numeric constants. Uses NUM.TWENTYTWO to compute node radius:
+ *   nodeRadius = Math.min(w, h) / NUM.TWENTYTWO.
  */
 function drawTree(ctx, w, h, colors, NUM) {
   /* Tree-of-Life: 10 nodes with 22 connective paths.

--- a/js/helix-renderer.test.mjs
+++ b/js/helix-renderer.test.mjs
@@ -1,0 +1,180 @@
+/*
+  helix-renderer.test.mjs
+  Thorough unit tests for helix-renderer.mjs.
+
+  Testing framework note:
+  - Uses existing globals (Vitest/Jest/Mocha) for describe/it hooks if present.
+  - Otherwise falls back to Node's built-in 'node:test' via a tiny adapter below.
+  - Assertions use Node 'assert/strict' to avoid introducing any new dependencies.
+*/
+
+import assert from 'node:assert/strict';
+import { renderHelix } from './helix-renderer.mjs';
+
+// Adapter: ensure describe/it exist in environments without a test framework
+if (typeof globalThis.describe === 'undefined') {
+  const t = await import('node:test');
+  globalThis.describe = t.describe;
+  globalThis.it = t.it || t.test;
+  globalThis.beforeEach = t.beforeEach;
+  globalThis.afterEach = t.afterEach;
+}
+
+const { describe, it, beforeEach, afterEach } = globalThis;
+
+const NUM = Object.freeze({
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  NINETYNINE: 99,
+  THIRTYTHREE: 33,
+  TWENTYTWO: 22,
+  ONEFORTYFOUR: 144,
+});
+
+const defaultPalette = Object.freeze({
+  bg: '#101018',
+  ink: '#0f0f0f',
+  layers: [
+    '#d11a1a', // vesica
+    '#1ad11a', // tree paths
+    '#1a1ad1', // tree nodes
+    '#d1d11a', // fibonacci
+    '#d11ad1', // helix A
+    '#1ad1d1', // helix B
+  ],
+});
+
+// Minimal CanvasRenderingContext2D spy to record drawing operations
+function createCtxMock() {
+  const state = { fillStyle: null, strokeStyle: null, lineWidth: 1 };
+  const events = [];
+  const snapshot = () => ({ fillStyle: state.fillStyle, strokeStyle: state.strokeStyle, lineWidth: state.lineWidth });
+  const record = (op, payload) => events.push({ t: events.length, op, ...payload, state: snapshot() });
+
+  const ctx = {};
+  for (const prop of ['fillStyle', 'strokeStyle', 'lineWidth']) {
+    Object.defineProperty(ctx, prop, {
+      get() { return state[prop]; },
+      set(v) { state[prop] = v; record('set', { prop, value: v }); },
+      enumerable: true,
+    });
+  }
+  const method = name => (...args) => record('call', { method: name, args });
+  ['save', 'restore', 'beginPath', 'stroke', 'fill'].forEach(m => (ctx[m] = method(m)));
+  ctx.arc = method('arc');
+  ctx.moveTo = method('moveTo');
+  ctx.lineTo = method('lineTo');
+  ctx.fillRect = method('fillRect');
+
+  return { ctx, events };
+}
+
+// Helpers
+function countCalls(events, method) {
+  return events.filter(e => e.op === 'call' && e.method === method).length;
+}
+function callsByStyle(events, method, styleKey, color) {
+  return events.filter(e => e.op === 'call' && e.method === method && e.state[styleKey] === color);
+}
+function firstSetIndex(events, prop, value) {
+  return events.findIndex(e => e.op === 'set' && e.prop === prop && e.value === value);
+}
+
+describe('renderHelix (ND-safe static renderer)', () => {
+  let ctx, events;
+  const W = 210;
+  const H = 210;
+  const palette = defaultPalette;
+
+  beforeEach(() => {
+    ({ ctx, events } = createCtxMock());
+  });
+
+  it('fills the background once and wraps with balanced save/restore', () => {
+    renderHelix(ctx, { width: W, height: H, palette, NUM });
+
+    // 1 outer save/restore + 1 per layer (4)
+    assert.strictEqual(countCalls(events, 'save'), 5, 'outer save + 4 layer saves');
+    assert.strictEqual(countCalls(events, 'restore'), 5, 'outer restore + 4 layer restores');
+
+    const idxBgSet = firstSetIndex(events, 'fillStyle', palette.bg);
+    assert.ok(idxBgSet >= 0, 'bg fillStyle set');
+
+    const fills = events.filter(e => e.op === 'call' && e.method === 'fillRect');
+    assert.strictEqual(fills.length, 1, 'background filled once');
+    assert.deepStrictEqual(fills[0].args, [0, 0, W, H], 'fills entire canvas');
+    assert.ok(idxBgSet < events.indexOf(fills[0]), 'bg color set before fillRect');
+  });
+
+  it('applies layer colors in documented order (vesica → tree paths → fibonacci → helix A → helix B → rungs)', () => {
+    renderHelix(ctx, { width: W, height: H, palette, NUM });
+
+    const order = {
+      vesica: firstSetIndex(events, 'strokeStyle', palette.layers[0]),
+      treePaths: firstSetIndex(events, 'strokeStyle', palette.layers[1]),
+      fibonacci: firstSetIndex(events, 'strokeStyle', palette.layers[3]),
+      helixA: firstSetIndex(events, 'strokeStyle', palette.layers[4]),
+      helixB: firstSetIndex(events, 'strokeStyle', palette.layers[5]),
+      rungs: firstSetIndex(events, 'strokeStyle', palette.ink),
+    };
+    for (const [name, idx] of Object.entries(order)) {
+      assert.ok(idx >= 0, `found color set for ${name}`);
+    }
+    assert.ok(order.vesica < order.treePaths &&
+              order.treePaths < order.fibonacci &&
+              order.fibonacci < order.helixA &&
+              order.helixA < order.helixB &&
+              order.helixB < order.rungs, 'layer color set events are ordered');
+  });
+
+  it('draws Fibonacci spiral as one path with 144 segments and a single stroke', () => {
+    renderHelix(ctx, { width: W, height: H, palette, NUM });
+
+    assert.strictEqual(callsByStyle(events, 'beginPath', 'strokeStyle', palette.layers[3]).length, 1, 'one beginPath');
+    assert.strictEqual(callsByStyle(events, 'stroke', 'strokeStyle', palette.layers[3]).length, 1, 'one stroke');
+    assert.strictEqual(callsByStyle(events, 'lineTo', 'strokeStyle', palette.layers[3]).length, NUM.ONEFORTYFOUR, '144 segments');
+  });
+
+  it('renders Tree-of-Life with 22 path segments and 10 filled nodes', () => {
+    renderHelix(ctx, { width: W, height: H, palette, NUM });
+
+    assert.strictEqual(callsByStyle(events, 'lineTo', 'strokeStyle', palette.layers[1]).length, 22, '22 connective paths');
+    assert.strictEqual(callsByStyle(events, 'fill', 'fillStyle', palette.layers[2]).length, 10, '10 node fills');
+  });
+
+  it('renders double-helix: 99 segments per strand and 33+1 rungs with proper line widths', () => {
+    renderHelix(ctx, { width: W, height: H, palette, NUM });
+
+    assert.strictEqual(callsByStyle(events, 'lineTo', 'strokeStyle', palette.layers[4]).length, 99, 'strand A segments');
+    assert.strictEqual(callsByStyle(events, 'lineTo', 'strokeStyle', palette.layers[5]).length, 99, 'strand B segments');
+
+    const rungSegments = callsByStyle(events, 'lineTo', 'strokeStyle', palette.ink);
+    assert.strictEqual(rungSegments.length, NUM.THIRTYTHREE + 1, '33 cross rungs plus endpoint');
+    rungSegments.forEach(ev => assert.strictEqual(ev.state.lineWidth, 1, 'rung line width is 1'));
+  });
+
+  it('draws a deterministic vesica grid (arc count matches geometry for 210×210)', () => {
+    renderHelix(ctx, { width: W, height: H, palette, NUM });
+
+    const baseRadius = Math.min(W, H) / NUM.THREE;
+    const step = baseRadius / NUM.SEVEN;
+    const stepDelta = step * NUM.NINE;
+
+    const countAxis = (span, start, delta) => {
+      let c = 0;
+      for (let pos = start; pos < span; pos += delta) c++;
+      return c;
+    };
+    const expected = countAxis(H, baseRadius, stepDelta) * countAxis(W, baseRadius, stepDelta) * 2;
+
+    const vesicaArcs = callsByStyle(events, 'arc', 'strokeStyle', palette.layers[0]);
+    assert.strictEqual(vesicaArcs.length, expected, 'vesica arc count matches grid geometry');
+  });
+
+  it('is resilient to zero-size canvases (no throw)', () => {
+    const small = createCtxMock();
+    assert.doesNotThrow(() => renderHelix(small.ctx, { width: 0, height: 0, palette, NUM }));
+  });
+});

--- a/test/index-html.test.mjs
+++ b/test/index-html.test.mjs
@@ -1,0 +1,335 @@
+// Testing library & framework note:
+// This test uses Node's built-in test runner (node:test) and assert/strict for zero-dependency compatibility.
+// If your project uses Jest/Vitest, this file should still run under node >=18. For Jest/Vitest, you can adapt
+// the imports (e.g., describe/it) or run it as-is with "node --test". No new dependencies introduced.
+
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// The HTML under test (focus on the diff-provided content)
+const INDEX_HTML = String.raw`<\!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root {
+      --bg: #0b0b12;
+      --ink: #e8e8f0;
+      --muted: #a6a6c1;
+    }
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 14px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    }
+    header {
+      padding: 12px 16px;
+      border-bottom: 1px solid #1d1d2a;
+    }
+    .status {
+      color: var(--muted);
+      font-size: 12px;
+    }
+    #stage {
+      display: block;
+      margin: 16px auto;
+      box-shadow: 0 0 0 1px #1d1d2a;
+    }
+    .note {
+      max-width: 900px;
+      margin: 0 auto 16px;
+      color: var(--muted);
+    }
+    code {
+      background: #11111a;
+      padding: 2px 4px;
+      border-radius: 3px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+
+    const canvas = document.getElementById("stage");
+
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+
+      try {
+
+        const res = await fetch(path, { cache: "no-store" });
+
+        if (!res.ok) throw new Error(String(res.status));
+
+        return await res.json();
+
+      } catch (error) {
+
+        return null;
+
+      }
+    }
+
+    const defaults = {
+
+      palette: {
+
+        bg: "#0b0b12",
+
+        ink: "#e8e8f0",
+
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+
+      }
+
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+
+    const active = palette || defaults.palette;
+
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by the geometry routines
+
+    const NUM = {
+
+      THREE: 3,
+
+      SEVEN: 7,
+
+      NINE: 9,
+
+      ELEVEN: 11,
+
+      TWENTYTWO: 22,
+
+      THIRTYTHREE: 33,
+
+      NINETYNINE: 99,
+
+      ONEFORTYFOUR: 144
+
+    };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+
+    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
+  </script>
+</body>
+</html>`;
+
+// Minimal HTML parser utilities for the assertions (no external deps).
+// These helpers are intentionally simple and tailored to the structure we need to validate.
+
+function extractTag(html, tag) {
+  const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
+  const m = html.match(re);
+  return m ? { full: m[0], inner: m[1] } : null;
+}
+
+function getAttribute(tagHtml, attr) {
+  const re = new RegExp(`${attr}\\s*=\\s*"(.*?)"`, 'i');
+  const m = tagHtml.match(re);
+  return m ? m[1] : null;
+}
+
+function queryById(html, id) {
+  const re = new RegExp(`<([a-zA-Z]+)\\b[^>]*id\\s*=\\s*"${id}"[^>]*>`, 'i');
+  const m = html.match(re);
+  return m ? { tag: m[1], full: m[0] } : null;
+}
+
+function hasMetaNameContent(html, name, contentPrefix) {
+
+  const pattern = '<meta\\s+[^>]*name\\s*=\\s*"' + name + '"[^>]*>';
+  const re = new RegExp(pattern, 'i');
+  const found = html.match(re);
+  if (!found) return false;
+
+  const content = getAttribute(found[0], 'content');
+
+  return typeof content === 'string' && content.startsWith(contentPrefix);
+}
+
+function getCanvasDimension(tagHtml, dim) {
+
+  const val = getAttribute(tagHtml, dim);
+
+  return val ? Number(val) : NaN;
+
+}
+
+function extractInlineModuleScript(html) {
+
+  const re = /<script\s+type="module">([\s\S]*?)<\/script>/i;
+
+  const m = html.match(re);
+
+  return m ? m[1].trim() : null;
+
+}
+
+describe('index.html structure and inline module behavior (focused on diff content)', () => {
+  let html;
+
+  beforeEach(() => {
+    html = INDEX_HTML;
+  });
+
+  test('includes correct doctype and html lang attribute', () => {
+
+    assert.ok(html.toLowerCase().startsWith('<\\!doctype html>'), 'DOCTYPE should be HTML5');
+
+    const htmlTag = html.match(/<html\b[^>]*>/i)?.[0] ?? '';
+
+    assert.match(htmlTag, /lang="en"/i, 'html lang should be "en"');
+
+  });
+
+  test('head contains essential meta and title per ND-safe guidance', () => {
+
+    const head = extractTag(html, 'head');
+
+    assert.ok(head, '<head> should exist');
+
+    assert.ok(/<meta\s+charset="utf-8"/i.test(head.full), 'UTF-8 charset meta is present');
+
+    assert.ok(/<title>Cosmic Helix Renderer \(ND-safe, Offline\)<\/title>/.test(head.full), 'Title matches exactly');
+
+    assert.ok(hasMetaNameContent(head.full, 'viewport', 'width=device-width,initial-scale=1'), 'Viewport meta configured');
+
+    assert.ok(hasMetaNameContent(head.full, 'color-scheme', 'light dark'), 'color-scheme meta configured');
+
+    const style = extractTag(head.inner, 'style');
+
+    assert.ok(style, '<style> block exists');
+
+    assert.match(style.inner, /:root\s*{[\s\S]*--bg:\s*#0b0b12;[\s\S]*--ink:\s*#e8e8f0;[\s\S]*--muted:\s*#a6a6c1;[\s\S]*}/, 'CSS variables are defined');
+
+  });
+
+  test('body includes header with status element default text', () => {
+
+    const body = extractTag(html, 'body');
+
+    assert.ok(body, '<body> should exist');
+
+    const status = queryById(body.inner, 'status');
+
+    assert.ok(status, '#status element exists');
+    assert.equal(status.tag.toLowerCase(), 'div');
+    assert.match(status.full, />\s*Loading palette\.\.\.\s*<\//, '#status default text indicates loading state');
+
+  });
+
+  test('canvas stage has expected dimensions and aria-label for a11y', () => {
+
+    const canvas = queryById(html, 'stage');
+
+    assert.ok(canvas, 'canvas#stage exists');
+    assert.equal(canvas.tag.toLowerCase(), 'canvas');
+
+    assert.equal(getCanvasDimension(canvas.full, 'width'), 1440);
+    assert.equal(getCanvasDimension(canvas.full, 'height'), 900);
+
+    const aria = getAttribute(canvas.full, 'aria-label');
+
+    assert.equal(aria, 'Layered sacred geometry canvas', 'canvas has descriptive aria-label');
+
+  });
+
+  test('inline module: uses fetch with cache: "no-store" and safe palette fallback', () => {
+
+    const code = extractInlineModuleScript(html);
+
+    assert.ok(code, 'Inline module script is present');
+
+    // Check fetch pattern and caching directive
+
+    assert.match(code, /fetch\(path,\s*{\s*cache:\s*"no-store"\s*}\s*\)/, 'fetch uses no-store');
+
+    // Fallback palette structure
+
+    assert.match(code, /const\s+defaults\s*=\s*{\s*palette:\s*{[\s\S]*bg:\s*"#0b0b12"[\s\S]*ink:\s*"#e8e8f0"[\s\S]*layers:\s*\[[\s\S]*\][\s\S]*}\s*}/, 'defaults.palette is defined with bg, ink, layers');
+
+    // Status messaging reflects fallback vs loaded
+
+    assert.match(code, /elStatus\.textContent\s*=\s*palette\s*\?\s*"Palette loaded\."\s*:\s*"Palette missing; using safe fallback\.";/, 'status message logic is correct');
+
+  });
+
+  test('inline module: defines expected NUM constants used by geometry routines', () => {
+
+    const code = extractInlineModuleScript(html);
+
+    assert.ok(code);
+
+    const expected = {
+
+      THREE: 3,
+
+      SEVEN: 7,
+
+      NINE: 9,
+
+      ELEVEN: 11,
+
+      TWENTYTWO: 22,
+
+      THIRTYTHREE: 33,
+
+      NINETYNINE: 99,
+
+      ONEFORTYFOUR: 144,
+    };
+    for (const [k, v] of Object.entries(expected)) {
+
+      const re = new RegExp(`${k}\\s*:\\s*${v}\\b`);
+
+      assert.match(code, re, `NUM.${k} equals ${v}`);
+    }
+
+  });
+
+  test('inline module: calls renderHelix with canvas ctx, dimensions, palette, and NUM', () => {
+
+    const code = extractInlineModuleScript(html);
+
+    assert.ok(code);
+
+    // Validate presence of getContext and renderHelix invocation signature
+
+    assert.match(code, /const\s+ctx\s*=\s*canvas\.getContext\("2d"\)\s*;/, '2D context requested');
+    assert.match(code, /renderHelix\(\s*ctx\s*,\s*{\s*width:\s*canvas\.width\s*,\s*height:\s*canvas\.height\s*,\s*palette:\s*active\s*,\s*NUM\s*}\s*\)\s*;/, 'renderHelix called with expected args');
+  });
+
+  test('inline module: loadJSON returns null on network errors (try/catch path present)', () => {
+
+    const code = extractInlineModuleScript(html);
+
+    assert.ok(code);
+
+    // Ensure rejection path is handled (catch returns null)
+
+    assert.match(code, /try\s*{[\s\S]*}\s*catch\s*\(\s*error\s*\)\s*{\s*return\s+null;\s*}/, 'loadJSON safely returns null on errors');
+  });
+});

--- a/test/palette.test.mjs
+++ b/test/palette.test.mjs
@@ -1,0 +1,167 @@
+// Note: Testing library/framework
+// These tests are written to run with Node's built-in test runner (node:test) and node:assert/strict.
+// If your project uses Jest or Vitest, the assertions and structure are compatible with minimal changes.
+// Prefer running with: node --test test/palette.test.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Helper: locate palette JSON file from common locations
+function resolvePalettePath() {
+  const candidates = [
+    'src/palette.json',
+    'palette.json',
+    'config/palette.json',
+    'data/palette.json',
+    'assets/palette.json',
+  ];
+  for (const rel of candidates) {
+    const p = path.resolve(__dirname, '..', rel);
+    if (fs.existsSync(p)) return p;
+  }
+  // Fallback: in case the palette is co-located near tests
+  const local = path.resolve(__dirname, 'palette.json');
+  if (fs.existsSync(local)) return local;
+
+  // As a last resort, we embed the expected content from the diff and validate against it.
+  return null;
+}
+
+// Expected snippet from diff focus (treat as source-of-truth for tests)
+const expected = {
+  bg: '#0b0b12',
+  ink: '#e8e8f0',
+  layers: ['#b1c7ff', '#89f7fe', '#a0ffa1', '#ffd27f', '#f5a3ff', '#d0d0e6'],
+};
+
+// Load palette either from file or use embedded expected for validation structure
+function loadPalette() {
+  const p = resolvePalettePath();
+  if (p) {
+    const raw = fs.readFileSync(p, 'utf8');
+    try {
+      return JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`Failed to parse palette JSON at ${p}: ${e.message}`);
+    }
+  }
+  // If no file found, validate against embedded expected (ensures tests still provide value)
+  return structuredClone(expected);
+}
+
+// Utils
+const HEX6 = /^#[0-9a-fA-F]{6}$/;
+
+function hexToRgb(hex) {
+  assert.match(hex, HEX6, `Invalid hex color: ${hex}`);
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return [r, g, b];
+}
+
+// Relative luminance per WCAG
+function relLum([r, g, b]) {
+  const toLin = (c) => {
+    const x = c / 255;
+    return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+  const [R, G, B] = [toLin(r), toLin(g), toLin(b)];
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+function contrastRatio(fgHex, bgHex) {
+  const L1 = relLum(hexToRgb(fgHex));
+  const L2 = relLum(hexToRgb(bgHex));
+  const lighter = Math.max(L1, L2);
+  const darker = Math.min(L1, L2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function isUnique(arr) {
+  return new Set(arr).size === arr.length;
+}
+
+const palette = loadPalette();
+
+// Tests
+
+test('palette has required top-level keys and no unexpected types', () => {
+  assert.ok(palette && typeof palette === 'object', 'palette should be an object');
+  assert.ok('bg' in palette, 'bg key missing');
+  assert.ok('ink' in palette, 'ink key missing');
+  assert.ok('layers' in palette, 'layers key missing');
+
+  assert.equal(typeof palette.bg, 'string', 'bg should be string hex');
+  assert.equal(typeof palette.ink, 'string', 'ink should be string hex');
+  assert.ok(Array.isArray(palette.layers), 'layers should be an array');
+});
+
+test('palette hex values are valid 6-digit hex colors', () => {
+  assert.match(palette.bg, HEX6);
+  assert.match(palette.ink, HEX6);
+  for (const c of palette.layers) {
+    assert.equal(typeof c, 'string', 'layer color should be string');
+    assert.match(c, HEX6, `Invalid layer hex: ${c}`);
+  }
+});
+
+test('palette layers array is non-empty, within reasonable size, and unique', () => {
+  assert.ok(palette.layers.length > 0, 'layers should not be empty');
+  assert.ok(palette.layers.length <= 32, 'layers should not be excessively large');
+  assert.ok(isUnique(palette.layers), 'layers contain duplicates');
+});
+
+test('contrast between bg and ink meets WCAG AA for normal text (>= 4.5)', () => {
+  const ratio = contrastRatio(palette.ink, palette.bg);
+  assert.ok(ratio >= 4.5, `Contrast ratio too low: ${ratio.toFixed(2)} (expected >= 4.5)`);
+});
+
+test('each layer has sufficient contrast against bg for UI elements (>= 3.0)', () => {
+  for (const [idx, color] of palette.layers.entries()) {
+    const ratio = contrastRatio(color, palette.bg);
+    assert.ok(ratio >= 3.0, `Layer[${idx}] ${color} contrast ${ratio.toFixed(2)} < 3.0`);
+  }
+});
+
+test('diff-focused expectations: bg, ink, and specific layer sequence match', () => {
+  // This test ties directly to the diff content to ensure stability.
+  assert.equal(palette.bg.toLowerCase(), expected.bg);
+  assert.equal(palette.ink.toLowerCase(), expected.ink);
+  assert.equal(palette.layers.length, expected.layers.length, 'layers length changed from diff');
+  for (let i = 0; i < expected.layers.length; i++) {
+    assert.equal(
+      String(palette.layers[i]).toLowerCase(),
+      expected.layers[i],
+      `layers[${i}] differs from diff`
+    );
+  }
+});
+
+test('no near-duplicate colors (delta E proxy using simple RGB distance)', () => {
+  // We use a simple Euclidean RGB distance as a proxy to catch extremely similar colors.
+  // Threshold chosen conservatively.
+  const toVec = (hex) => hexToRgb(hex);
+  const thresh = 10; // 0..441 range; 10 is very close
+  const all = [palette.bg, palette.ink, ...palette.layers];
+  for (let i = 0; i < all.length; i++) {
+    for (let j = i + 1; j < all.length; j++) {
+      const [a, b] = [toVec(all[i]), toVec(all[j])];
+      const dist = Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+      assert.ok(dist >= thresh, `Colors too similar: ${all[i]} vs ${all[j]} (dist=${dist.toFixed(2)})`);
+    }
+  }
+});
+
+test('palette JSON does not include extraneous keys', () => {
+  const allowed = new Set(['bg', 'ink', 'layers']);
+  for (const k of Object.keys(palette)) {
+    assert.ok(allowed.has(k), `Unexpected key in palette: ${k}`);
+  }
+});

--- a/test/readme.test.mjs
+++ b/test/readme.test.mjs
@@ -1,0 +1,232 @@
+/**
+ * README Contract Tests
+ *
+ * Framework note:
+ * - Prefers Vitest (import from "vitest") if available in the project.
+ * - Falls back to Jest ESM (import from "@jest/globals") if Vitest isn't present.
+ * - As a last resort, uses Node's built-in 'assert' with minimal shims.
+ *
+ * These tests validate the public documentation contract introduced in the PR diff:
+ * - Title, sections, and ordered "Layers" contents and numerology constants
+ * - Presence of important phrases and invariants (counts like 3,7,9,11,22,33,99,144)
+ * - Usage claims (index.html path mention and optional palette.json mention)
+ * - ND-safe choices list items
+ *
+ * The tests aim to be resilient to minor formatting changes while still catching
+ * regressions in wording and critical numbers.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+function findFirstExisting(paths) {
+  for (const p of paths) {
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+const readmeCandidates = [
+  path.join(repoRoot, "README.md"),
+  path.join(repoRoot, "Readme.md"),
+  path.join(repoRoot, "readme.md"),
+  path.join(repoRoot, "README.MD"),
+  path.join(repoRoot, "docs", "README.md"),
+];
+const readmePath = findFirstExisting(readmeCandidates);
+const indexHtmlPath = findFirstExisting([
+  path.join(repoRoot, "index.html"),
+  path.join(repoRoot, "public", "index.html"),
+  path.join(repoRoot, "static", "index.html"),
+]);
+const palettePath = path.join(repoRoot, "data", "palette.json");
+
+const readmeText = (() => {
+  if (!readmePath) return null;
+  try {
+    return fs.readFileSync(readmePath, "utf8");
+  } catch (e) {
+    return null;
+  }
+})();
+
+function norm(s) {
+  return (s || "").replace(/\r\n/g, "\n");
+}
+
+function numbersIn(str) {
+  return (str.match(/\d+/g) || []).map((n) => Number(n));
+}
+
+(async () => {
+  // Lightweight dynamic test harness selection
+  let t = null;
+  try {
+    // Prefer Vitest if present
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    const vitest = await import("vitest").catch(() => null);
+    if (vitest && vitest.describe) {
+      t = {
+        framework: "vitest",
+        describe: vitest.describe,
+        it: vitest.it,
+        test: vitest.test,
+        expect: vitest.expect,
+        beforeAll: vitest.beforeAll,
+        skip: vitest.it.skip,
+      };
+    }
+  } catch (e) {}
+
+  if (!t) {
+    try {
+      // Fallback to Jest ESM globals
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      const jestg = await import("@jest/globals").catch(() => null);
+      if (jestg && jestg.describe) {
+        t = {
+          framework: "jest",
+          describe: jestg.describe,
+          it: jestg.it,
+          test: jestg.test,
+          expect: jestg.expect,
+          beforeAll: jestg.beforeAll || ((fn) => fn()),
+          skip: jestg.it.skip,
+        };
+      }
+    } catch (e) {}
+  }
+
+  if (!t) {
+    // Last resort: Node assert shim with minimal structure
+    const assert = await import("node:assert");
+    t = {
+      framework: "node-assert",
+      describe: (name, fn) => fn(),
+      it: (name, fn) => fn(),
+      test: (name, fn) => fn(),
+      expect: (val) => ({
+        toBeTruthy: () => assert.ok(val),
+        toContain: (needle) => assert.ok(String(val).includes(needle)),
+        toMatch: (re) => assert.ok(re.test(String(val))),
+        toEqual: (other) => assert.deepStrictEqual(val, other),
+        toBe: (other) => assert.strictEqual(val, other),
+        toBeGreaterThan: (n) => assert.ok(val > n),
+        toBeGreaterThanOrEqual: (n) => assert.ok(val >= n),
+        toBeLessThan: (n) => assert.ok(val < n),
+      }),
+      beforeAll: (fn) => fn(),
+      skip: (_name, _fn) => void 0,
+    };
+  }
+
+  const { describe, it, expect, beforeAll, skip } = t;
+
+  // Shared preconditions
+  let txt;
+  beforeAll(() => {
+    txt = norm(readmeText);
+  });
+
+  describe(`[Docs][${t.framework}] README contract`, () => {
+    it("README file should exist at a conventional path", () => {
+      if (!readmePath) {
+        // Provide a descriptive failure for maintainers
+        throw new Error(
+          `README not found. Checked: ${readmeCandidates.join(", ")}`
+        );
+      }
+      expect(fs.existsSync(readmePath)).toBeTruthy();
+    });
+
+    it("Contains the title and epigraph line near the top", () => {
+      expect(txt).toBeTruthy();
+      expect(txt).toContain("# Cosmic Helix Renderer");
+      expect(txt).toMatch(/Per Texturas Numerorum,\s*Spira Loquitur\./);
+    });
+
+    it("Describes the renderer as static, offline, no build or network, ND-safe", () => {
+      expect(txt).toMatch(/Static,\s*offline canvas renderer/i);
+      expect(txt).toMatch(/No build step/i);
+      expect(txt).toMatch(/no network calls/i);
+      expect(txt).toMatch(/ND-safe by design/i);
+    });
+
+    it("Has key section headings", () => {
+      for (const h of [
+        /^##\s+Layers/m,
+        /^##\s+Usage/m,
+        /^##\s+ND-safe choices/m,
+        /^##\s+Numerology constants/m,
+      ]) {
+        expect(txt).toMatch(h);
+      }
+    });
+
+    it("Lists the four Layers in the documented order", () => {
+      const names = [
+        "Vesica field",
+        "Tree-of-Life scaffold",
+        "Fibonacci curve",
+        "Double-helix lattice",
+      ];
+      const positions = names.map((n) => txt.indexOf(n));
+      // All present
+      positions.forEach((p) => expect(p).toBeGreaterThanOrEqual(0));
+      // In ascending order
+      for (let i = 1; i < positions.length; i++) {
+        expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+      }
+    });
+
+    it("Layer numerics match the spec (3,7,9) (10 & 22) (144) (33)", () => {
+      const vesica = /Vesica field[\s\S]*?\(\s*3\s*,\s*7\s*,\s*9\s*\)/i;
+      const tree = /Tree-of-Life scaffold[\s\S]*?10\s+nodes?\s+with\s+22\s+connective paths/i;
+      const fib = /Fibonacci curve[\s\S]*?144\s+sampled points/i;
+      const helix = /Double-helix lattice[\s\S]*?33\s+cross rungs/i;
+
+      expect(txt).toMatch(vesica);
+      expect(txt).toMatch(tree);
+      expect(txt).toMatch(fib);
+      expect(txt).toMatch(helix);
+    });
+
+    it("Usage section mentions opening index.html and optional data/palette.json with fallback notice", () => {
+      expect(txt).toMatch(/Open\s+`?index\.html`?/i);
+      expect(txt).toMatch(/data\/palette\.json/i);
+      expect(txt).toMatch(/fallback palette/i);
+      expect(txt).toMatch(/notice/i);
+    });
+
+    it("ND-safe choices enumerate key constraints (no animation/autoplay/flashing, gentle contrast, preserved depth without motion)", () => {
+      expect(txt).toMatch(/No animation,\s*autoplay,\s*or flashing\./i);
+      expect(txt).toMatch(/Gentle contrast/i);
+      expect(txt).toMatch(/preserves depth without motion/i);
+    });
+
+    it("Numerology constants section lists the expected set", () => {
+      const sectionMatch = txt.match(/##\s*Numerology constants([\s\S]*?)$/m);
+      expect(sectionMatch).toBeTruthy();
+      const numbers = numbersIn(sectionMatch ? sectionMatch[1] : "");
+      // Unique and sorted for comparison
+      const uniq = Array.from(new Set(numbers)).sort((a, b) => a - b);
+      expect(uniq).toEqual([3, 7, 9, 11, 22, 33, 99, 144]);
+    });
+
+    // File presence checks tied to docs (skipped if files are absent to keep tests helpful, not flaky)
+    (indexHtmlPath ? it : skip)("index.html exists where documentation expects it", () => {
+      expect(fs.existsSync(indexHtmlPath)).toBeTruthy();
+    });
+
+    // palette.json is optional by design; ensure test does not require it to exist
+    it("Documentation states palette.json is optional; test does not require it to exist", () => {
+      // This is a no-op assertion that the doc claim was validated in the Usage test.
+      expect(true).toBeTruthy();
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- tidy the offline index page with a single ND-safe status flow and fallback palette handling
- rewrite the helix renderer module into small pure layer functions driven by numerology constants
- fix the palette JSON and refresh the renderer readme to describe safety and usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8da45f7508328affdaa5d84e5e4de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clarified how to customize colors via the palette file.
  - Deterministic, non-animated rendering for consistent visuals.

- Bug Fixes
  - Removed a duplicate status element in the header.
  - Fixed a duplicate “layers” entry in the palette to avoid conflicts.

- Style
  - Improved typography, spacing, and punctuation consistency across the UI.

- Documentation
  - Updated wording and terminology for clarity, including numerology references and layer descriptions.

- Refactor
  - Streamlined layer rendering for clearer structure and predictable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->