### PR TITLE
Refine cosmic helix renderer layers

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -11,14 +11,13 @@ Static, offline canvas demo for layered sacred geometry. No build step, no netwo
 4. **Double-helix lattice** — two phase-shifted strands with 33 cross rungs
 
 ## Usage
-- Open `index.html` directly in any modern browser.
-- Optional: edit `data/palette.json` to change colors; if missing, a calm fallback palette is used and the header shows a notice.
+- Open `index.html` directly in any modern browser (offline-first).
+- Optional: edit `data/palette.json` to change colors; if the file is missing the header shows a calm fallback notice and the default palette is used.
 
 ## ND-safe choices
-- No animation, autoplay, or flashing.
-- Gentle contrast with readable inks on dark background.
-- Layer order preserves depth without motion.
+- No animation, autoplay, or flashing; every layer renders once.
+- Gentle contrast with readable inks on dark background; palette overrides stay ND-safe via sane defaults.
+- Layer order preserves depth without motion so the geometry feels dimensional yet steady.
 
 ## Numerology constants
-The renderer uses constants that echo Fibonacci and Tarot harmonics: 3, 7, 9, 11, 22, 33, 99, 144.
-Constants exposed in `index.html` as `NUM` feed the geometry: 3, 7, 9, 11, 22, 33, 99, 144.
+The renderer exposes constants (3, 7, 9, 11, 22, 33, 99, 144) in `index.html` as `NUM` so each geometric routine remains grounded in the requested harmonics.

--- a/data/palette.json
+++ b/data/palette.json
@@ -9,5 +9,4 @@
     "#f5a3ff",
     "#d0d0e6"
   ]
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 }

--- a/index.html
+++ b/index.html
@@ -8,8 +8,13 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system, Segoe UI, Roboto, sans-serif; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    html, body {
+      margin:0;
+      padding:0;
+      background:var(--bg);
+      color:var(--ink);
+      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+    }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -21,7 +26,6 @@
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette...</div>
-    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -39,9 +43,27 @@
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
-      } catch {
+      } catch (err) {
+        console.warn("Palette unavailable, using fallback palette.", err);
         return null;
       }
+    }
+
+    function normalizePalette(candidate, fallback) {
+      if (!candidate) return fallback;
+      const bg = typeof candidate.bg === "string" ? candidate.bg : fallback.bg;
+      const ink = typeof candidate.ink === "string" ? candidate.ink : fallback.ink;
+      const hasLayers = Array.isArray(candidate.layers) && candidate.layers.length >= 6;
+      const rawLayers = hasLayers ? candidate.layers.slice(0, 6) : fallback.layers;
+      const trimmed = rawLayers.map((value) => (typeof value === "string" ? value.trim() : ""));
+      const layers = trimmed.map((value, index) => value || fallback.layers[index]);
+      return { bg, ink, layers };
+    }
+
+    function applyDocumentPalette(palette) {
+      const root = document.documentElement.style;
+      root.setProperty("--bg", palette.bg);
+      root.setProperty("--ink", palette.ink);
     }
 
     const defaults = {
@@ -52,14 +74,15 @@
       }
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const paletteData = await loadJSON("./data/palette.json");
+    const active = normalizePalette(paletteData, defaults.palette);
+    applyDocumentPalette(active);
+    elStatus.textContent = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Numerology constants used by geometry routines
+    // Numerology constants used by geometry routines (3, 7, 9, 11, 22, 33, 99, 144)
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    // ND-safe rationale: render once, no motion, layered order preserves depth gently.
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
   </script>
 </body>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -2,21 +2,14 @@
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-  Layers:
-    1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
-    3) Fibonacci curve (log spiral polyline)
-    4) Double-helix lattice (two phase-shifted strands)
-
-  All functions are pure and run once; no motion, no dependencies.
   Layers drawn in order:
     1) Vesica field — intersecting circles forming a calm grid
-    2) Tree-of-Life scaffold — 10 sephirot nodes + 22 paths
-    3) Fibonacci curve — logarithmic spiral using 144 sampled points
-    4) Double-helix lattice — two phase-shifted strands with 33 cross rungs
+    2) Tree-of-Life scaffold — 10 sephirot nodes with 22 paths
+    3) Fibonacci curve — logarithmic spiral using 144 samples
+    4) Double-helix lattice — two phase-shifted strands with 33 rungs
 
-  All functions are pure and run once; no motion, no dependencies.
-  Functions are pure and run once; no motion, no dependencies.
+  All functions are pure (no shared state) and execute once to honor the
+  no-motion requirement.
 */
 
 export function renderHelix(ctx, { width, height, palette, NUM }) {
@@ -24,89 +17,35 @@ export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  // Layer order preserves depth without motion
   drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawTree(ctx, width, height, {
+    path: palette.layers[1],
+    node: palette.layers[2]
+  }, NUM);
   drawFibonacci(ctx, width, height, palette.layers[3], NUM);
   drawHelix(ctx, width, height, {
-    a: palette.layers[4],
-    b: palette.layers[5],
+    strandA: palette.layers[4],
+    strandB: palette.layers[5],
     rung: palette.ink
   }, NUM);
-  drawHelix(ctx, width, height, { a: palette.layers[4], b: palette.layers[5], rung: palette.ink }, NUM);
 
   ctx.restore();
 }
 
-/* Layer 1: Vesica field — calm grid of intersecting circles */
 /* Layer 1: Vesica field ---------------------------------------------------- */
-/* Layer 1: Vesica field -- calm grid of intersecting circles */
 function drawVesica(ctx, w, h, color, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // triadic radius
-  const step = r / NUM.SEVEN;           // septenary spacing
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-function drawVesica(ctx, w, h, color, NUM) {
-  /* Vesica field: calm outline grid built from overlapping circles.
-     ND-safe: thin lines, generous spacing. */
-  const r = Math.min(w, h) / NUM.THREE;      // base radius from sacred triad
-  const step = r / NUM.SEVEN;                // spacing guided by 7
-/* Layer 1: Vesica field — calm grid of intersecting circles */
-function drawVesica(ctx, w, h, color, NUM) {
-  // ND-safe: thin lines, generous spacing
-  const r = Math.min(w, h) / NUM.THREE;       // triadic radius
-  const step = r / NUM.SEVEN;                 // septenary spacing
+  /* Vesica field: calm lattice of overlapping circles.
+     ND-safe: thin strokes and wide spacing prevent overstimulation. */
+  const r = Math.min(w, h) / NUM.THREE;      // triadic radius anchor
+  const step = r / NUM.SEVEN;                // septenary spacing factor
 
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 1;
+  ctx.globalAlpha = 0.75;
 
-  for (let y = r; y < h; y += step * NUM.NINE) {
-    for (let x = r; x < w; x += step * NUM.NINE) {
-      ctx.beginPath(); ctx.arc(x - step, y, r, 0, Math.PI * 2); ctx.stroke();
-      ctx.beginPath(); ctx.arc(x + step, y, r, 0, Math.PI * 2); ctx.stroke();
-    }
-  }
-
-/* Layer 2: Tree-of-Life scaffold — nodes and connective paths */
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  const nodes = [
-    [0.5, 0.1], [0.65, 0.2], [0.35, 0.2],
-    [0.7, 0.4], [0.3, 0.4], [0.5, 0.5],
-    [0.75, 0.7], [0.25, 0.7], [0.5, 0.8],
-  ctx.restore();
-}
-
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------- */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  /* Tree-of-Life: 10 sephirot nodes linked by 22 paths.
-     ND-safe: static layout, thin lines. */
-
-  const nodes = [
-    [0.5, 0.05], [0.75, 0.18], [0.25, 0.18],
-    [0.25, 0.38], [0.75, 0.38], [0.5, 0.52],
-    [0.25, 0.66], [0.75, 0.66], [0.5, 0.8], [0.5, 0.93]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const paths = [
-    [0,1],[0,2],[0,5],
-    [1,2],[1,5],[1,4],
-    [2,3],[2,5],[2,4],
-    [3,5],[3,6],
-    [4,5],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,7],[6,8],[6,9],
-    [7,8],[7,9],
-    [8,9]
+  for (let y = r; y <= h - r / 2; y += step * NUM.NINE) {
+    for (let x = r; x <= w - r / 2; x += step * NUM.NINE) {
       ctx.beginPath();
       ctx.arc(x - step, y, r, 0, Math.PI * 2);
       ctx.stroke();
@@ -119,289 +58,151 @@ function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
   ctx.restore();
 }
 
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------ */
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  /* Tree-of-Life: 10 nodes with 22 connective paths.
-     ND-safe: static layout, readable contrast. */
-  const nodes = [
-    [0.5, 0.05], [0.75, 0.15], [0.25, 0.15],
-    [0.75, 0.35], [0.25, 0.35], [0.5, 0.45],
-    [0.75, 0.65], [0.25, 0.65], [0.5, 0.75], [0.5, 0.90]
+/* Layer 2: Tree-of-Life scaffold ------------------------------------------- */
+function drawTree(ctx, w, h, colors, NUM) {
+  /* Tree-of-Life: 10 nodes linked by 22 connective paths.
+     ND-safe: static placement, gentle strokes, high legibility. */
+  const baseNodes = [
+    [0.5, 0.05],  // Keter
+    [0.7, 0.18],  // Chokmah
+    [0.3, 0.18],  // Binah
+    [0.75, 0.36], // Chesed
+    [0.25, 0.36], // Geburah
+    [0.5, 0.52],  // Tiphareth
+    [0.7, 0.66],  // Netzach
+    [0.3, 0.66],  // Hod
+    [0.5, 0.8],   // Yesod
+    [0.5, 0.93]   // Malkuth
   ];
-  const edges = [
-    [0,1],[0,2],
-    [1,3],[1,4],[1,5],
-    [2,3],[2,4],[2,5],
-    [3,5],[3,6],[3,7],
-    [4,5],[4,6],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,8],[6,9],
-    [7,8],[7,9],
-    [8,9]
-      ctx.beginPath();
-      ctx.arc(x - step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-      ctx.beginPath();
-      ctx.arc(x + step, y, r, 0, Math.PI * 2);
-      ctx.stroke();
-    }
-  }
-  ctx.restore();
-}
-
-/* Layer 2: Tree-of-Life scaffold -- nodes and paths */
-function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
-  const pts = [
-    [0.5, 0.1],
-    [0.25, 0.2],
-    [0.75, 0.2],
-    [0.25, 0.4],
-    [0.75, 0.4],
-    [0.5, 0.5],
-    [0.25, 0.7],
-    [0.75, 0.7],
-    [0.5, 0.8],
-    [0.5, 0.9]
-  ].map(([x, y]) => [x * w, y * h]);
+  const nodes = baseNodes.map(([x, y]) => [x * w, y * h]);
 
   const edges = [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],
-    [3,6],[4,7],[6,7],[6,8],[7,8],[8,9],[5,6],[5,7],
-    [5,8],[2,5],[1,5],[2,3],[1,4],[0,5]
-    [0,1],[0,2],[1,2],[1,3],[1,5],[2,4],[2,5],[3,4],[3,5],[3,6],
-    [4,5],[4,7],[5,6],[5,7],[5,8],[6,8],[6,9],[7,8],[7,9],[8,9],
-    [1,7],[2,8]
-  ctx.restore();
-}
-
-/* Layer 2: Tree-of-Life scaffold ------------------------------------------- */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  /* Tree-of-Life: 10 sephirot nodes linked by 22 paths.
-     ND-safe: static layout, thin lines. */
-
-  const nodes = [
-    [0.5, 0.05], [0.75, 0.18], [0.25, 0.18],
-    [0.25, 0.38], [0.75, 0.38], [0.5, 0.52],
-    [0.25, 0.66], [0.75, 0.66], [0.5, 0.8], [0.5, 0.93]
-  ].map(([x, y]) => [x * w, y * h]);
-
-  const paths = [
-    [0,1],[0,2],[0,5],
-    [1,2],[1,5],[1,4],
-    [2,3],[2,5],[2,4],
-    [3,5],[3,6],
-    [4,5],[4,7],
-    [5,6],[5,7],[5,8],
-    [6,7],[6,8],[6,9],
-    [7,8],[7,9],
-    [8,9]
+    [0, 1], [0, 2],
+    [1, 2], [1, 3], [1, 5], [1, 6],
+    [2, 4], [2, 5], [2, 7],
+    [3, 4], [3, 5], [3, 6],
+    [4, 5], [4, 7],
+    [5, 6], [5, 7], [5, 8],
+    [6, 7], [6, 8], [6, 9],
+    [7, 8],
+    [8, 9]
   ];
 
   ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  paths.forEach(([a, b]) => {
-    const [x1, y1] = nodes[a];
-    const [x2, y2] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(x1, y1);
-    ctx.lineTo(x2, y2);
+  ctx.strokeStyle = colors.path;
+  ctx.lineWidth = 1.5;
+  ctx.globalAlpha = 0.9;
 
-  edges.forEach(([a,b]) => {
-    const ax = nodes[a][0] * w, ay = nodes[a][1] * h;
-    const bx = nodes[b][0] * w, by = nodes[b][1] * h;
+  edges.forEach(([a, b]) => {
+    const [ax, ay] = nodes[a];
+    const [bx, by] = nodes[b];
     ctx.beginPath();
     ctx.moveTo(ax, ay);
     ctx.lineTo(bx, by);
     ctx.stroke();
   });
 
-  ctx.fillStyle = nodeColor;
-  const r = Math.min(w, h) / NUM.TWENTYTWO;
+  ctx.fillStyle = colors.node;
+  const nodeRadius = Math.min(w, h) / (NUM.NINETYNINE / 2);
   nodes.forEach(([x, y]) => {
     ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.arc(x, y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
   });
 
   ctx.restore();
 }
 
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
+/* Layer 3: Fibonacci curve -------------------------------------------------- */
 function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci spiral: static logarithmic curve.
-     ND-safe: single stroke, no motion. */
-  nodes.forEach(([x,y]) => {
-    ctx.beginPath();
-    ctx.arc(x * w, y * h, r, 0, Math.PI * 2);
-    ctx.fill();
-  });
+  /* Fibonacci logarithmic spiral: 144 samples expressing gentle growth.
+     ND-safe: single static stroke maintains calm focus. */
+  const total = NUM.ONEFORTYFOUR;
+  const center = [w * 0.33, h * 0.72];
+  const baseRadius = Math.min(w, h) / NUM.TWENTYTWO;
+  const growth = Math.log(NUM.NINETYNINE) / total; // smooth exponential scaling
+  const angleStep = Math.PI / NUM.ELEVEN;
 
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
-  ctx.lineWidth = 1.5;
-  edges.forEach(([a, b]) => {
-    ctx.beginPath();
-  ctx.lineWidth = 1.5;
-  edges.forEach(([a, b]) => {
-    ctx.beginPath();
-    ctx.moveTo(pts[a][0], pts[a][1]);
-    ctx.lineTo(pts[b][0], pts[b][1]);
-  ctx.restore();
-}
-
-/* Layer 2: Tree-of-Life scaffold — nodes and paths */
-function drawTree(ctx, w, h, nodeColor, pathColor, NUM) {
-  // Layout approximates the sefirot; static and evenly spaced
-  const cx = w / 2;
-  const top = h / NUM.NINE;
-  const bottom = h - top;
-  const middle = (top + bottom) / 2;
-  const quarter = (top + middle) / 2;
-  const threeQuarter = (middle + bottom) / 2;
-
-  const nodes = [
-    [cx, top],
-    [cx - w / NUM.SEVEN, quarter],
-    [cx + w / NUM.SEVEN, quarter],
-    [cx - w / NUM.NINE, middle],
-    [cx + w / NUM.NINE, middle],
-    [cx, middle + h / NUM.TWENTYTWO],
-    [cx - w / NUM.NINE, threeQuarter],
-    [cx + w / NUM.NINE, threeQuarter],
-    [cx, bottom - h / NUM.ELEVEN],
-    [cx, bottom]
-  ];
-
-  const paths = [
-    [0,1],[0,2],[1,3],[2,4],[3,4],[3,5],[4,5],[3,6],[4,7],[6,7],[6,8],[7,8],[5,8],[8,9]
-  ];
-
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = 1;
-  edges.forEach(([a, b]) => {
-    ctx.beginPath();
-    ctx.moveTo(nodes[a][0], nodes[a][1]);
-    ctx.lineTo(nodes[b][0], nodes[b][1]);
-
-  paths.forEach(([a,b]) => {
-    const [x1,y1] = nodes[a];
-    const [x2,y2] = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(x1, y1);
-    ctx.lineTo(x2, y2);
-    ctx.stroke();
-  });
-
-  ctx.fillStyle = nodeColor;
-  const r = Math.min(w, h) / NUM.TWENTYTWO;
-  nodes.forEach(([x, y]) => {
-  pts.forEach(([x, y]) => {
-    ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
-    ctx.fill();
-  });
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve -- static logarithmic spiral */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Logarithmic spiral with fixed samples.
-     ND-safe: static polyline, no motion. */
-
-  ctx.restore();
-}
-
-/* Layer 3: Fibonacci curve ------------------------------------------------- */
-function drawFibonacci(ctx, w, h, color, NUM) {
-  /* Fibonacci spiral: static logarithmic curve.
-     ND-safe: single stroke, no motion. */
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const samples = NUM.ONEFORTYFOUR;               // 144 points
-  const scale = Math.min(w, h) / NUM.THIRTYTHREE; // gentle size
-  const cx = w / 2;
-  const cy = h / 2;
+  const points = [];
+  for (let i = 0; i < total; i += 1) {
+    const theta = i * angleStep;
+    const radius = baseRadius * Math.exp(growth * i);
+    const x = center[0] + Math.cos(theta) * radius;
+    const y = center[1] - Math.sin(theta) * radius;
+    points.push([x, y]);
+  }
 
   ctx.save();
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
-  ctx.beginPath();
-
-  for (let i = 0; i <= samples; i++) {
-    const theta = i * (Math.PI / NUM.ELEVEN);
-    const r = scale * Math.pow(phi, theta / Math.PI);
-    const x = w / 2 + Math.cos(theta) * r;
-    const y = h / 2 - Math.sin(theta) * r;
-    const r = scale * Math.pow(phi, theta / (Math.PI * 2));
-    const x = cx + Math.cos(theta) * r;
-    const y = cy + Math.sin(theta) * r;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-
-  ctx.stroke();
+  ctx.globalAlpha = 0.85;
+  drawPolyline(ctx, points);
   ctx.restore();
 }
 
-/* Layer 4: Double-helix lattice — two static strands with rungs */
-/* Layer 4: Double-helix lattice ------------------------------------------- */
+/* Layer 4: Double-helix lattice -------------------------------------------- */
 function drawHelix(ctx, w, h, colors, NUM) {
-  /* Double-helix lattice: two static strands with cross rungs.
-     ND-safe: even spacing, no motion. */
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
-/* Layer 4: Double-helix lattice -- two static strands with rungs */
-function drawHelix(ctx, w, h, colors, NUM) {
-  const amp = h / NUM.NINE;       // gentle amplitude
-  const waves = NUM.ELEVEN;       // helix turns
-  const steps = NUM.NINETYNINE;   // sampling
-/* Layer 4: Double-helix lattice — two static strands with rungs */
-function drawHelix(ctx, w, h, colors, NUM) {
-  // ND-safe: even spacing, no motion
-  const amp = h / NUM.NINE;
-  const waves = NUM.ELEVEN;
-  const steps = NUM.NINETYNINE;
+  /* Double helix: two offset strands linked by 33 cross rungs.
+     ND-safe: static geometry, balanced spacing via numerology constants. */
+  const strandA = buildStrand(w, h, NUM, 0);
+  const strandB = buildStrand(w, h, NUM, Math.PI);
 
   ctx.save();
   ctx.lineWidth = 2;
+  ctx.globalAlpha = 0.9;
 
-  ctx.strokeStyle = colors.a;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
+  ctx.strokeStyle = colors.strandA;
+  drawPolyline(ctx, strandA);
+  ctx.strokeStyle = colors.strandB;
+  drawPolyline(ctx, strandB);
 
-  ctx.strokeStyle = colors.b;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i++) {
-    const t = i / steps;
-    const x = t * w;
-    const y = h / 2 + Math.sin(t * waves * 2 * Math.PI + Math.PI) * amp;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.stroke();
-
-  // cross rungs
   ctx.strokeStyle = colors.rung;
   ctx.lineWidth = 1;
-  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
-    const t = i / NUM.THIRTYTHREE;
-    const x = t * w;
-    const phase = t * waves * 2 * Math.PI;
-    const y1 = h / 2 + Math.sin(phase) * amp;
-    const y2 = h / 2 + Math.sin(phase + Math.PI) * amp;
+  const rungTotal = NUM.THIRTYTHREE;
+  const step = (strandA.length - 1) / (rungTotal - 1);
+  for (let i = 0; i < rungTotal; i += 1) {
+    const idx = Math.round(i * step);
+    const safeIdx = Math.min(idx, strandA.length - 1, strandB.length - 1);
+    const [ax, ay] = strandA[safeIdx];
+    const [bx, by] = strandB[safeIdx];
     ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
     ctx.stroke();
   }
 
   ctx.restore();
+}
+
+function buildStrand(w, h, NUM, phaseShift) {
+  const samples = NUM.NINETYNINE;
+  const top = h * 0.12;
+  const span = h * 0.76;
+  const mid = w * 0.5;
+  const amplitude = w / NUM.TWENTYTWO;
+  const frequency = (Math.PI * 2 * NUM.THIRTYTHREE) / NUM.ELEVEN;
+
+  const points = [];
+  for (let i = 0; i < samples; i += 1) {
+    const t = i / (samples - 1);
+    const y = top + t * span;
+    const angle = t * frequency + phaseShift;
+    const offset = Math.sin(angle) * amplitude;
+    points.push([mid + offset, y]);
+  }
+  return points;
+}
+
+/* Shared helper ------------------------------------------------------------- */
+function drawPolyline(ctx, points) {
+  if (!Array.isArray(points) || points.length < 2) {
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(points[0][0], points[0][1]);
+  for (let i = 1; i < points.length; i += 1) {
+    const [x, y] = points[i];
+    ctx.lineTo(x, y);
+  }
+  ctx.stroke();
 }


### PR DESCRIPTION
## Summary
- clean the offline index shell and normalize palette fallbacks for ND-safe rendering
- rebuild the helix renderer module with pure layer functions honoring numerology constants
- fix the shared palette data and renderer README for clarity

## Testing
- node --check js/helix-renderer.mjs

------
https://chatgpt.com/codex/tasks/task_e_68c951a3765c8328bbd3c8f3da21d0c0