### PR TITLE
Restructure site build for Netlify publish

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 *.png  filter=lfs diff=lfs merge=lfs -text
-*.tif  filter=lfs diff=lfs merge=lfs -text
-*.tiff filter=lfs diff=lfs merge=lfs -text
-*.exr  filter=lfs diff=lfs merge=lfs -text
-*.hdr  filter=lfs diff=lfs merge=lfs -text
+*.jpg  filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
+*.avif filter=lfs diff=lfs merge=lfs -text

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,14 @@
+[build]
+  publish = "site"
+  command = ""
+  [build.environment]
+    GIT_LFS_ENABLED = "true"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Content-Security-Policy = "default-src 'self' https: data:; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https:; script-src 'self' https:; connect-src 'self' https:; frame-ancestors 'none';"

--- a/site/assets/css/atelier.css
+++ b/site/assets/css/atelier.css
@@ -1,0 +1,310 @@
+:root {
+  --bg: #08080f;
+  --ink: #f4f4fb;
+  --muted: #b3b3d4;
+  --accent: #8ae6ff;
+  --accent-soft: #ffd7a8;
+  --accent-secondary: #c9a0ff;
+  --surface: #111122;
+  --surface-alt: #18182a;
+  --border: #252545;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font: 16px/1.6 "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 8px;
+  padding: 8px 12px;
+  background: var(--surface);
+  color: var(--ink);
+  text-decoration: none;
+  border-radius: 4px;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  left: 16px;
+}
+
+.atelier-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 32px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.marque-logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.15em;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.nav-collection {
+  list-style: none;
+  display: flex;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-collection a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.nav-collection a:hover,
+.nav-collection a:focus {
+  color: var(--ink);
+}
+
+.btn-couture {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.reduced-motion .btn-couture {
+  transition: none;
+}
+
+.btn-couture:hover,
+.btn-couture:focus {
+  background: var(--accent);
+  color: #00151f;
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 32px 96px;
+}
+
+.section {
+  margin-bottom: 80px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero-copy .lead {
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+.callouts {
+  display: grid;
+  gap: 8px;
+  color: var(--accent-soft);
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-block;
+  margin-top: 16px;
+  padding: 10px 18px;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #00151f;
+}
+
+.btn-secondary {
+  background: var(--accent-secondary);
+  color: #190029;
+}
+
+.btn-primary:hover,
+.btn-secondary:hover,
+.btn-primary:focus,
+.btn-secondary:focus {
+  opacity: 0.85;
+}
+
+.hero-figure {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  padding: 16px;
+  border-radius: 16px;
+  text-align: center;
+}
+
+.hero-figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+}
+
+.hero-figure figcaption {
+  font-size: 0.85rem;
+  margin-top: 12px;
+  color: var(--muted);
+}
+
+.arcana-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.arcana-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.arcana-card h3 {
+  margin-top: 0;
+}
+
+.arcana-card p {
+  color: var(--muted);
+}
+
+.nodes {
+  display: grid;
+  gap: 24px;
+}
+
+.nodes-header p {
+  color: var(--muted);
+}
+
+.node-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.node-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.node-details {
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.node-details div {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
+}
+
+.node-details dt {
+  font-weight: 600;
+}
+
+.node-details dd {
+  margin: 0;
+  color: var(--muted);
+}
+
+.node-summary {
+  margin: 0;
+  color: var(--muted);
+}
+
+.node-fallback {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.atelier-list {
+  margin: 16px 0;
+  padding-left: 20px;
+  color: var(--muted);
+}
+
+.maison-footer {
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  padding: 24px 32px 32px;
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.footer-links a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.footer-links a:hover,
+.footer-links a:focus {
+  color: var(--ink);
+}
+
+@media (max-width: 720px) {
+  .atelier-nav {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .nav-collection {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  main {
+    padding: 24px 20px 80px;
+  }
+}
+
+.reduced-motion * {
+  transition: none !important;
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+}

--- a/site/assets/img/hero.avif
+++ b/site/assets/img/hero.avif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98a048823afdb5e2ed0a08fe45051800358211ecce1383598e3547f9f9793ff5
+size 591

--- a/site/assets/js/calm.js
+++ b/site/assets/js/calm.js
@@ -1,0 +1,6 @@
+const prefersReduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+if (prefersReduced) document.documentElement.classList.add('reduced-motion');
+document.getElementById('calmToggle')?.addEventListener('click', () => {
+  const active = document.documentElement.classList.toggle('reduced-motion');
+  document.getElementById('calmToggle').setAttribute('aria-pressed', String(active));
+});

--- a/site/assets/js/nodes.js
+++ b/site/assets/js/nodes.js
@@ -1,0 +1,56 @@
+const DATA_URL = 'data/nodes.json';
+
+/**
+ * Fetch node registry data from disk.
+ * The routine is pure: same input URL yields same JSON payload.
+ */
+async function fetchNodes(url) {
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok) throw new Error(`Failed to load nodes: ${response.status}`);
+  const payload = await response.json();
+  return Array.isArray(payload.nodes) ? payload.nodes : [];
+}
+
+/**
+ * Clone the node template and populate details for the calm reader.
+ */
+function createNodeCard(template, node) {
+  const fragment = template.content.cloneNode(true);
+  fragment.querySelector('.node-title').textContent = node.title;
+  fragment.querySelector('.node-alignment').textContent = node.alignment;
+  fragment.querySelector('.node-frequency').textContent = node.frequency;
+  fragment.querySelector('.node-summary').textContent = node.summary;
+  return fragment;
+}
+
+/**
+ * Render the node cards into the target element or show the fallback notice.
+ */
+function renderNodes(target, nodes, template, fallback) {
+  if (!target) return;
+  const docFrag = document.createDocumentFragment();
+  if (nodes.length === 0) {
+    if (fallback) fallback.hidden = false;
+    target.replaceChildren();
+    return;
+  }
+  nodes.forEach((node) => {
+    docFrag.appendChild(createNodeCard(template, node));
+  });
+  target.replaceChildren(docFrag);
+  if (fallback) fallback.hidden = true;
+}
+
+(async function initNodeSystem() {
+  const target = document.querySelector('[data-node-list]');
+  const template = document.getElementById('node-template');
+  const fallback = document.querySelector('.node-fallback');
+  if (!target || !template) return;
+  try {
+    const nodes = await fetchNodes(DATA_URL);
+    renderNodes(target, nodes, template, fallback);
+  } catch (error) {
+    console.error(error);
+    if (fallback) fallback.hidden = false;
+  }
+})();

--- a/site/data/nodes.json
+++ b/site/data/nodes.json
@@ -1,0 +1,22 @@
+{
+  "nodes": [
+    {
+      "title": "Aurora Node",
+      "alignment": "Triune Harmonics",
+      "frequency": "3 : 9 : 27",
+      "summary": "Maintains the Vesica overlays for the renderer; keeps intersections luminous without triggering motion." 
+    },
+    {
+      "title": "Sephira Conduit",
+      "alignment": "Tree Circuit",
+      "frequency": "7 : 11 : 22",
+      "summary": "Maps each sephirot to calm study paths so the offline grids mirror the ND-safe atelier cadence." 
+    },
+    {
+      "title": "Spiral Archive",
+      "alignment": "Fibonacci Memory",
+      "frequency": "33 : 66 : 99",
+      "summary": "Stores static polyline spirals and annotates ratios for analog journaling sequences." 
+    }
+  ]
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>COSMOGENESIS — Cathedral of Circuits</title>
+  <meta name="description" content="A living grimoire: sacred geometry, techno-occult research, and spiral learning." />
+  <link rel="preload" href="assets/img/hero.avif" as="image" />
+  <link rel="stylesheet" href="assets/css/atelier.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <nav class="atelier-nav">
+    <a href="#collections" class="marque-logo">COSMOGENESIS</a>
+    <ul class="nav-collection">
+      <li><a href="#collections">Collections</a></li>
+      <li><a href="#arcana">Living Arcana</a></li>
+      <li><a href="#node-system">Node System</a></li>
+      <li><a href="#atelier">Atelier</a></li>
+    </ul>
+    <button id="calmToggle" class="btn-couture" aria-pressed="false">Calm Mode</button>
+  </nav>
+
+  <main id="main">
+    <section id="collections" class="section hero">
+      <div class="hero-copy">
+        <h1>Cathedral of Circuits</h1>
+        <p class="lead">An offline sanctuary for techno-mystics. Each collection threads luminous research, analog rituals, and modular learning rituals into a gentle lattice.</p>
+        <div class="callouts">
+          <p>• Harmonic diagrams curated for neurodivergent focus.</p>
+          <p>• Layered geometry studies with zero autoplay or flicker.</p>
+          <p>• Printable field guides for traveling ateliers.</p>
+        </div>
+        <a class="btn-primary" href="#arcana">Enter the living grimoire</a>
+      </div>
+      <figure class="hero-figure">
+        <img src="assets/img/hero.avif" alt="Layered aurora geometry over a tranquil circuit cathedral" width="720" height="480" loading="lazy" />
+        <figcaption>ND-safe tapestry: depth without motion, layered for calm study.</figcaption>
+      </figure>
+    </section>
+
+    <section id="arcana" class="section arcana">
+      <h2>Living Arcana</h2>
+      <p>Spiral curricula tuned to constants 3, 7, 9, 11, 22, 33, 99, and 144. Each sequence keeps the cosmic helix renderer offline-first and annotation-ready.</p>
+      <div class="arcana-grid">
+        <article class="arcana-card">
+          <h3>Vesica Field Notes</h3>
+          <p>Printable diagrams layering intersecting circles for meditative drafting. Includes guidance for tracing without inducing motion fatigue.</p>
+        </article>
+        <article class="arcana-card">
+          <h3>Tree-of-Life Routes</h3>
+          <p>Stepwise walks through sephirot pairings. Each route mirrors the renderer&apos;s calm luminance palette for consistent sensory grounding.</p>
+        </article>
+        <article class="arcana-card">
+          <h3>Fibonacci Spirals</h3>
+          <p>Static polyline studies mapping growth ratios to analog journaling prompts. Designed for layered note-taking and offline reference.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="node-system" class="section nodes">
+      <div class="nodes-header">
+        <h2>Node System</h2>
+        <p>The Cathedral archives manifest as constellated nodes. Loadouts below are rendered locally; no network calls are required beyond this page.</p>
+      </div>
+      <div class="node-list" data-node-list></div>
+      <template id="node-template">
+        <article class="node-card">
+          <h3 class="node-title"></h3>
+          <dl class="node-details">
+            <div>
+              <dt>Alignment</dt>
+              <dd class="node-alignment"></dd>
+            </div>
+            <div>
+              <dt>Frequency</dt>
+              <dd class="node-frequency"></dd>
+            </div>
+          </dl>
+          <p class="node-summary"></p>
+        </article>
+      </template>
+      <p class="node-fallback" hidden>Node registry is offline; explore README_RENDERER.md for manual schematics.</p>
+    </section>
+
+    <section id="atelier" class="section atelier">
+      <h2>Atelier Commissions</h2>
+      <p>Collaborate on quiet, layered renderings. Each commission respects sensory pacing, shipping printable files instead of animated screens.</p>
+      <ul class="atelier-list">
+        <li><strong>Resonant Atlases:</strong> Multi-layer canvases prepared for community rituals.</li>
+        <li><strong>Calm Installations:</strong> Exhibition-ready static canvases with annotated geometry.</li>
+        <li><strong>Learning Spirals:</strong> Offline-first study sequences for small circles.</li>
+      </ul>
+      <a class="btn-secondary" href="labs/void-lab.html">Visit the Void Lab</a>
+    </section>
+  </main>
+
+  <footer class="maison-footer">
+    <div class="footer-marque">COSMOGENESIS</div>
+    <div class="footer-links">
+      <a href="#collections">Harmonic Research</a>
+      <a href="#node-system">Node System Docs</a>
+      <a href="https://github.com/your-org/your-repo" rel="noopener noreferrer">Open Source</a>
+      <a href="#atelier">Commissions</a>
+    </div>
+    <p class="copyright">© MMXXV — Cathedral of Circuits</p>
+  </footer>
+
+  <script type="module" src="assets/js/calm.js"></script>
+  <script type="module" src="assets/js/nodes.js"></script>
+</body>
+</html>

--- a/site/labs/void-lab.html
+++ b/site/labs/void-lab.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Void Lab — COSMOGENESIS</title>
+  <link rel="stylesheet" href="../assets/css/atelier.css" />
+  <style>
+    body { padding: 32px; max-width: 720px; margin: 0 auto; }
+    a { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Void Lab</h1>
+    <p>This chamber stores works in progress for the Cathedral of Circuits. Each experiment stays offline, static, and layered for neurodivergent calm.</p>
+    <ul class="atelier-list">
+      <li>Static prototypes for helix lattice arrangements.</li>
+      <li>Palette tests grounded in the ND-safe spectrum.</li>
+      <li>Printable overlays for vesica and sephira harmonics.</li>
+    </ul>
+    <p><a href="../index.html">Return to the main grimoire</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Netlify configuration that publishes the new site/ directory with security headers
- introduce site assets, hero image, and calm mode scripts to deliver the Cathedral of Circuits landing page
- track image assets with Git LFS for optimized media management

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc51c474048328ac37d0f4e8ff60b1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Launched a redesigned, responsive homepage with dark theme, accessible navigation, skip link, and Calm Mode toggle.
  - Added dynamic “Node System” that loads entries from local data with a graceful offline fallback.
  - Introduced hero image and cohesive visual system for typography, cards, and layout.
  - Published a new “Void Lab” page highlighting experiments and resources.

- Chores
  - Optimized asset management by updating which image formats use large-file storage.
  - Added hosting configuration with strict security headers and LFS support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->