### PR TITLE
Guard PNG masters and serve hero art via WebP manifest

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-*.png  filter=lfs diff=lfs merge=lfs -text
 *.jpg  filter=lfs diff=lfs merge=lfs -text
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 *.avif filter=lfs diff=lfs merge=lfs -text
+*.png -filter -diff -merge

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ assets/figures-src/
 Thumbs.db
 __pycache__/
 *.pyc
+
+# keep forbidden masters out of the repo
+site/assets/art/black-madonna-master.png

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status-text">Loading palette...</div>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -57,7 +57,7 @@
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const statusEl = document.getElementById("status-text");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
@@ -81,10 +81,10 @@
 
     const palette = await loadJSON("./data/palette.json");
     const activePalette = palette || fallbackPalette;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing or blocked; using safe fallback.";
+    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // Numerology constants anchor all geometry calculations.
-    const NUM = Object.freeze({
+    const NUM = {
       THREE: 3,
       SEVEN: 7,
       NINE: 9,
@@ -93,7 +93,7 @@
       THIRTYTHREE: 33,
       NINETYNINE: 99,
       ONEFORTYFOUR: 144
-    });
+    };
 
     // ND-safe rationale: no motion, high readability, gentle colors, ordered layers.
     renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: activePalette, NUM });

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   publish = "site"
   command = ""
   [build.environment]
-    GIT_LFS_ENABLED = "true"
+    GIT_LFS_ENABLED = "false"
 
 [[headers]]
   for = "/*"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "prebuild": "node scripts/verify-absent.mjs",
+    "build": "npm run test"
   }
 }

--- a/scripts/verify-absent.mjs
+++ b/scripts/verify-absent.mjs
@@ -1,0 +1,13 @@
+// verify-absent.mjs
+// ND-safe guard: fail build if forbidden PNG masters resurface.
+import { existsSync } from 'node:fs';
+
+const tombs = ['site/assets/art/black-madonna-master.png'];
+const risen = tombs.filter((path) => existsSync(path));
+
+if (risen.length > 0) {
+  console.error('PROTECT violation: undead asset(s) present:', risen);
+  process.exit(1);
+}
+
+console.log('Guard ok — no undead assets detected.');

--- a/site/assets/art/black-madonna-altar-1600.webp
+++ b/site/assets/art/black-madonna-altar-1600.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb4c2ea3a0bd7385ea1f7264c34612da010cf87b27249bb37aa6b02bc528617
+size 34

--- a/site/assets/art/manifest.json
+++ b/site/assets/art/manifest.json
@@ -1,0 +1,12 @@
+{
+  "_about": "WEBP-only live art",
+  "policy": {
+    "formats": ["webp"],
+    "nd_safe": true
+  },
+  "hero": {
+    "id": "black-madonna-altar",
+    "src": "/assets/art/black-madonna-altar-1600.webp",
+    "alt": "Black Madonna altar in obsidian and opal tones"
+  }
+}

--- a/site/assets/css/atelier.css
+++ b/site/assets/css/atelier.css
@@ -165,11 +165,17 @@ main {
   text-align: center;
 }
 
-.hero-figure img {
+.hero-figure canvas,
+.hero-figure .hero-art-slot img {
   display: block;
   width: 100%;
   height: auto;
   border-radius: 12px;
+}
+
+.hero-art-slot {
+  margin-top: 12px;
+  color: var(--muted);
 }
 
 .hero-figure figcaption {

--- a/site/assets/img/hero.avif
+++ b/site/assets/img/hero.avif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98a048823afdb5e2ed0a08fe45051800358211ecce1383598e3547f9f9793ff5
-size 591

--- a/site/assets/js/art-loader.js
+++ b/site/assets/js/art-loader.js
@@ -1,0 +1,37 @@
+// art-loader.js
+// ND-safe loader that enforces WEBP-only hero art with graceful fallback.
+export async function mountArt() {
+  let res;
+  try {
+    res = await fetch('/assets/art/manifest.json', { cache: 'no-store' });
+  } catch (error) {
+    console.warn('Art manifest request failed; keeping first-paint canvas visible.', error);
+    return;
+  }
+  if (!res.ok) {
+    console.warn('Art manifest unavailable; keeping first-paint canvas visible.');
+    return;
+  }
+  const manifest = await res.json();
+  if (!manifest?.hero?.src) {
+    console.warn('Art manifest missing hero src; nothing to mount.');
+    return;
+  }
+
+  const img = new Image();
+  img.loading = 'eager';
+  img.decoding = 'async';
+  img.src = manifest.hero.src;
+  img.alt = manifest.hero.alt || '';
+
+  const host = document.getElementById('hero-art');
+  if (host) {
+    host.textContent = '';
+    host.append(img);
+  }
+
+  const stage = document.getElementById('opus');
+  if (stage) {
+    stage.hidden = true;
+  }
+}

--- a/site/assets/js/first-paint-octagram.js
+++ b/site/assets/js/first-paint-octagram.js
@@ -1,0 +1,46 @@
+// first-paint-octagram.js
+// Renders a static octagram gradient as chapel-safe fallback when hero art is offline.
+export function paintOctagram(id = 'opus', width = 1200, height = 675) {
+  const canvas = document.getElementById(id);
+  if (!canvas) return;
+
+  canvas.width = width;
+  canvas.height = height;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const gradient = ctx.createRadialGradient(
+    width / 2,
+    height / 2,
+    width / 9,
+    width / 2,
+    height / 2,
+    Math.hypot(width, height) / 2
+  );
+
+  const palette = ['#0f0b1e', '#1d1d20', '#3b2e5a', '#bfa66b', '#dfe8ff'];
+  palette.forEach((color, index) => {
+    gradient.addColorStop(index / (palette.length - 1), color);
+  });
+
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.globalAlpha = 0.25;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = '#dfe8ff';
+
+  const radius = Math.min(width, height) * 0.32;
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  for (let k = 0; k < 8; k += 1) {
+    const angle = (Math.PI / 4) * k;
+    ctx.beginPath();
+    ctx.moveTo(centerX, centerY);
+    ctx.lineTo(centerX + radius * Math.cos(angle), centerY + radius * Math.sin(angle));
+    ctx.stroke();
+  }
+}

--- a/site/core/health-check.html
+++ b/site/core/health-check.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Cathedral Health ✓</title>
+<style>
+body {
+  font: 14px ui-monospace, monospace;
+  background: #0b0c10;
+  color: #e6e6e6;
+  padding: 2rem;
+}
+</style>
+<h1>Cathedral Health ✓</h1>
+<ul>
+  <li>Build: <script>document.write(new Date(document.lastModified).toISOString());</script></li>
+  <li>Auth: <span id="auth">none</span></li>
+</ul>
+<script>
+  const gated = document.cookie.includes('nf_jwt') || !!window.netlifyIdentity;
+  if (gated) {
+    document.getElementById('auth').textContent = 'possible gate detected';
+  }
+</script>

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>COSMOGENESIS — Cathedral of Circuits</title>
   <meta name="description" content="A living grimoire: sacred geometry, techno-occult research, and spiral learning." />
-  <link rel="preload" href="assets/img/hero.avif" as="image" />
+  <link rel="preload" href="assets/art/black-madonna-altar-1600.webp" as="image" type="image/webp" />
   <link rel="stylesheet" href="assets/css/atelier.css" />
 </head>
 <body>
@@ -34,7 +34,8 @@
         <a class="btn-primary" href="#arcana">Enter the living grimoire</a>
       </div>
       <figure class="hero-figure">
-        <img src="assets/img/hero.avif" alt="Layered aurora geometry over a tranquil circuit cathedral" width="720" height="480" loading="lazy" />
+        <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
+        <div id="hero-art" class="hero-art-slot" aria-live="polite">Hero art offline; canvas fallback active.</div>
         <figcaption>ND-safe tapestry: depth without motion, layered for calm study.</figcaption>
       </figure>
     </section>
@@ -106,6 +107,12 @@
     <p class="copyright">© MMXXV — Cathedral of Circuits</p>
   </footer>
 
+  <script type="module">
+    import { paintOctagram } from '/assets/js/first-paint-octagram.js';
+    import { mountArt } from '/assets/js/art-loader.js';
+    paintOctagram();
+    mountArt();
+  </script>
   <script type="module" src="assets/js/calm.js"></script>
   <script type="module" src="assets/js/nodes.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- disable PNG LFS filters, ignore the black-madonna master path, and add a prebuild guard to stop forbidden assets
- serve the hero art through a WebP manifest with a first-paint canvas fallback and updated hero markup/styles
- add a lightweight health-check page for build/auth visibility and align the offline renderer status text with the covenant

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ce54d9c41c8328a66dde7329a0827c