### PR TITLE
Add Cathedral Visionary ruleset metadata and registry

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -37,3 +37,7 @@ The renderer keeps these anchors in `index.html` to encode sacred ratios: 3, 7, 
 - Luminous halos provide layered geometry (never flat) inspired by the shared mandalas.
 - Canvas notices replace pop-ups to avoid startle.
 - No build tooling, bundlers, or workflows — everything remains offline-first and transparent.
+
+## Provenance Encoding
+- `index.html` embeds the Cathedral Visionary provenance JSON directly onto the canvas element.
+- This satisfies the Rosslyn ruleset requirement for metadata without introducing network calls or extra tooling.

--- a/REGISTRY/rulesets.json
+++ b/REGISTRY/rulesets.json
@@ -1,0 +1,53 @@
+{
+  "rulesets": {
+    "cathedral_visionary_v1": {
+      "name": "Cathedral Visionary 1.0",
+      "about": "Standards for rendering Rosslyn-inspired cathedrals, 21 Tara bands, and Morgan le Fey realms at atelier and Vienna Fantastic Realism quality.",
+      "composition": {
+        "full_view": true,
+        "no_cropping": true,
+        "frame_ratio": "phi (1:1.618)",
+        "center_axis": "vesica/double tree symmetry"
+      },
+      "geometry": {
+        "forms": ["octagon", "hexagram", "vesica", "cube"],
+        "double_tree": true,
+        "fractals": "allowed if phi-harmonic",
+        "ratios": ["phi", "pi", "3:2", "5:4", "7:4"]
+      },
+      "color_light": {
+        "taras": 21,
+        "style": "aurora-like silk bands",
+        "gold": "kintsugi lines highlight geometry",
+        "light_source": "inner radiant"
+      },
+      "style": {
+        "art_school": "Vienna Fantastic Realism (Fuchs, Hausner, Brauer)",
+        "japanese_principles": ["ma (spaciousness)", "shibumi (elegance)", "wabi-sabi (sacred asymmetry)"],
+        "mythic_context": "Morgan le Fey realm, enchanted order not chaos"
+      },
+      "perspective": {
+        "include_sky": true,
+        "include_ground": true,
+        "horizon_position": "phi from bottom",
+        "no_distortion": true
+      },
+      "provenance": {
+        "author": "Virelai Ezra Lux / Rebecca Respawn",
+        "license": "CC BY-NC",
+        "ruleset_id": "cathedral_visionary_v1",
+        "geometry": ["octagon", "hexagram", "vesica", "cube"],
+        "color_system": "21 Taras + gold",
+        "ratios": ["phi", "3:2", "5:4", "7:4"],
+        "style_refs": ["Vienna Fantastic Realism", "Japanese Ma/Shibumi", "Rosslyn Chapel"]
+      },
+      "worker_checks": [
+        "Confirm frame ratio = phi",
+        "Confirm full cathedral structure visible",
+        "Apply 21 Tara auroras correctly mapped",
+        "Embed provenance metadata in artifact",
+        "Reject render if symmetry, ratio, or provenance checks fail"
+      ]
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -94,6 +94,17 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
+    // Provenance metadata embedded per Cathedral Visionary standard.
+    const PROVENANCE = Object.freeze({
+      ruleset: "Cathedral Visionary 1.0",
+      geometry: ["octagon", "hexagram", "vesica", "cube"],
+      color_system: "21 Taras + gold",
+      ratios: ["phi", "3:2", "5:4", "7:4"],
+      style: ["Vienna Fantastic Realism", "Japanese Ma/Shibumi", "Rosslyn reference"],
+      full_view: true
+    });
+    canvas.dataset.provenance = JSON.stringify(PROVENANCE);
+
     async function loadJSON(path) {
       try {
         const response = await fetch(path, { cache: "no-store" });
@@ -118,35 +129,49 @@
     const usingFallback = !palette;
     const active = palette || defaults.palette;
 
+    const PHI = (1 + Math.sqrt(5)) / 2;
+    const phiTolerance = 0.03; // Allow slight deviation while respecting ND-safe 1440x900 brief.
+    const aspectRatio = canvas.width / canvas.height;
+    const ratioWithinPhi = Math.abs(aspectRatio - PHI) <= phiTolerance;
+
     elStatus.textContent = usingFallback
       ? "Palette fallback active — using bundled ND-safe tones."
       : "Palette loaded from data/palette.json.";
     elNote.hidden = !usingFallback;
 
-    // Numerology constants used by geometry routines.
-    const NUM = Object.freeze({
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
-    });
+    if (!ratioWithinPhi) {
+      elStatus.textContent = "Frame ratio check failed — adjust canvas to phi before rendering.";
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      // ND-safe guard: skip drawing if sacred proportion not respected.
+    } else {
+      // Numerology constants used by geometry routines.
+      const NUM = Object.freeze({
+        THREE: 3,
+        SEVEN: 7,
+        NINE: 9,
+        ELEVEN: 11,
+        TWENTYTWO: 22,
+        THIRTYTHREE: 33,
+        NINETYNINE: 99,
+        ONEFORTYFOUR: 144
+      });
 
-    const notice = usingFallback
-      ? "Palette fallback engaged. Sacred geometry rendered with bundled tones."
-      : "";
+      const notices = [];
+      if (usingFallback) {
+        notices.push("Palette fallback engaged. Sacred geometry rendered with bundled tones.");
+      }
 
-    // ND-safe rationale: no motion, high readability, gentle gradients, ordered layers.
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: active,
-      NUM,
-      notice
-    });
+      const notice = notices.join(" ");
+
+      // ND-safe rationale: no motion, high readability, gentle gradients, ordered layers.
+      renderHelix(ctx, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: active,
+        NUM,
+        notice
+      });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the Cathedral Visionary ruleset JSON to the registry for worker consumption
- embed the ruleset’s provenance metadata on the renderer canvas and enforce a phi-ratio guard before drawing
- document the embedded metadata workflow in the renderer README

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68d03cab7b40832887de5748254505be